### PR TITLE
ci: enforce ruff format check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,5 @@ jobs:
 
       - run: uv sync --all-extras
       - run: uv run ruff check .
+      - run: uv run ruff format --check .
       - run: uv run pytest


### PR DESCRIPTION
## Summary
- Add `uv run ruff format --check .` to the CI workflow after the ruff lint step
- Prevents unformatted code from merging to `main`
- Uses the simplified single-job workflow (no matrix)
## Context
Stale Dependabot PRs were failing on `ruff format --check` because they targeted an older branch with unformatted files. `main` already has formatted sources (`bc5665d`); this change enforces that going forward.
## Test plan
- [x] `uv run ruff format --check .` passes locally
- [x] `uv run ruff check .` passes locally
- [x] `uv run pytest` passes locally (3/3)
- [ ] CI `test` job passes on this PR