### PR TITLE
Fix/cyber cli ruff format

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# MCPAudit sponsorship and funding options
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [MCP-Audit]
+open_collective: mcp-audit
+polar: mcp-audit
+buy_me_a_coffee: mcpaudit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # MCPAudit
 
+![Python](https://img.shields.io/badge/python-3.11+-blue)
+![License](https://img.shields.io/badge/license-Apache%202.0-green)
+![Status](https://img.shields.io/badge/status-alpha-orange)
+![Security](https://img.shields.io/badge/focus-MCP%20Security-red)
+
 **Offensive security testing framework for Model Context Protocol (MCP) servers.**
 
 Make MCP security testing as easy as running a linter.
@@ -7,6 +12,35 @@ Make MCP security testing as easy as running a linter.
 ```bash
 mcpaudit scan ./server.py
 ```
+
+## Demo
+
+Scan the included vulnerable MCP server:
+
+```bash
+uv run mcpaudit scan examples/vulnerable-mcp-server/server.py
+```
+
+```
+$ mcpaudit scan examples/vulnerable-mcp-server/server.py
+[✓] Discovering tools...
+[✓] Mapping permissions...
+[✓] Detecting attack chains...
+[✓] Generating report...
+
+==================== MCPAudit Security Report ====================
+Overall Score:   5/100 (CRITICAL)
+Risk Index:      100/100
+Scoring basis:   3 Critical, 7 High, 2 Medium (12 scorable findings)
+Formula:         3×25 + 7×10 + 2×3 = 151 → round(100 × e^(-151/50)) = 5
+
+Severity Summary          Top Findings
+● Critical    4           [1] CRITICAL Destructive tool: delete_all_users
+● High        7           [2] CRITICAL Read → exfiltration attack chain possible
+● Medium      2           ...
+```
+
+> **Tip:** Record a terminal GIF of the scan above and add it here as `docs/assets/scan-demo.gif` for maximum README impact.
 
 ## Problem
 
@@ -22,7 +56,8 @@ MCP servers expose databases, APIs, file systems, cloud resources, and SaaS tool
 | Data Leakage Detection | ✅ Alpha | Scans for secrets and sensitive references |
 | Agent Jailbreak Testing | 🚧 Planned | Resistance scoring against jailbreak suites |
 | Multi-Step Attack Chains | ✅ Alpha | Identifies dangerous tool combinations |
-| Risk Scoring Engine | ✅ Alpha | CVSS-inspired security score (0–100) |
+| Risk Scoring Engine | ✅ Alpha | Security score + risk index (exponential decay) |
+| Terminal UI | ✅ Alpha | Rich dashboard, themes (`cyber`, `minimal`, `github`) |
 | Compliance Checks | ✅ Alpha | OWASP LLM Top 10 & MCP best practices |
 | CI/CD Integration | 🚧 Planned | GitHub Action for pipeline gates |
 | HTML Reports | ✅ Alpha | `mcpaudit report` → `security-report.html` |
@@ -39,8 +74,8 @@ MCP servers expose databases, APIs, file systems, cloud resources, and SaaS tool
 ### Install
 
 ```bash
-git clone https://github.com/hello-args/MCPVault.git
-cd MCPVault
+git clone https://github.com/MCP-Audit/MCPAudit.git
+cd MCPAudit
 uv sync --all-extras
 ```
 
@@ -61,6 +96,13 @@ uv run mcpaudit report report.json -o security-report.html
 
 ```bash
 uv run mcpaudit scan ./server.py --fail-on-critical
+```
+
+### Themes
+
+```bash
+uv run mcpaudit scan ./server.py --theme cyber    # default
+uv run mcpaudit scan ./server.py --theme minimal --no-progress
 ```
 
 ## Architecture

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,21 +5,38 @@
 Run a full security scan.
 
 ```bash
-mcpaudit scan <target> [--output report.json] [--fail-on-critical]
+mcpaudit scan <target> [--output report.json] [--fail-on-critical] [--theme cyber]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--output`, `-o` | Write JSON report to file |
 | `--fail-on-critical` | Exit code 1 if critical findings exist |
+| `--theme` | Terminal theme: `cyber` (default), `minimal`, `github` |
+| `--no-progress` | Skip pre-report progress animation |
+
+### Scoring output
+
+Each scan prints:
+
+- **Overall Score** — security score (higher is better), from exponential decay on weighted findings
+- **Risk Index** — raw risk capped at 100 (higher is worse)
+- **Scoring basis** — severity counts used (compliance meta-findings are excluded from the formula)
+
+JSON reports include `score.overall`, `score.risk_index`, `score.raw_risk`, and `score.basis`.
 
 ## `mcpaudit report`
 
 Generate HTML from a JSON scan report.
 
 ```bash
-mcpaudit report report.json [--output security-report.html]
+mcpaudit report report.json [--output security-report.html] [--theme cyber]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--output`, `-o` | HTML report path |
+| `--theme` | Terminal theme for status messages |
 
 ## `mcpaudit fuzz` (roadmap)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,22 +18,28 @@ MCPAudit performs static analysis on Python MCP servers, discovering `@tool` dec
 
 ## Example output
 
-```
-────────────────────── MCPAudit Security Report ──────────────────────
-Target: examples/vulnerable-mcp-server/server.py
-Overall Score: 42/100
+```text
+[✓] Discovering tools...
+[✓] Mapping permissions...
+[✓] Detecting attack chains...
+[✓] Generating report...
 
-        Findings by Severity
-┏━━━━━━━━━━┳━━━━━━━┓
-┃ Severity ┃ Count ┃
-┡━━━━━━━━━━╇━━━━━━━┩
-│ Critical │     3 │
-│ High     │     4 │
-...
+==================== MCPAudit Security Report ====================
+Overall Score:   5/100 (CRITICAL)
+Risk Index:      100/100
+Scoring basis:   3 Critical, 7 High, 2 Medium, 0 Low (12 scorable findings)
+
+● Critical    4
+● High        7
+● Medium      2
+● Low         0
 ```
+
+Scores are computed from findings (not hardcoded). See [CLI Reference](cli.md) for `--theme` and `--no-progress`.
 
 ## Next steps
 
 - Save JSON: `mcpaudit scan ./server.py -o report.json`
 - Generate HTML: `mcpaudit report report.json`
+- Try example servers: `examples/safe-mcp-server/`, `examples/medium-risk-mcp-server/`
 - Add to CI: see `action/action.yml`

--- a/examples/medium-risk-mcp-server/server.py
+++ b/examples/medium-risk-mcp-server/server.py
@@ -1,0 +1,20 @@
+"""Medium-risk MCP server — limited file access surface for scoring demos."""
+
+def create_app():
+    mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
+
+    @mcp.tool()
+    def read_file(path: str) -> str:
+        """Read a file from disk by path."""
+        return path
+
+    @mcp.tool()
+    def health_check() -> str:
+        """Return server health status."""
+        return "ok"
+
+    return mcp
+
+
+if __name__ == "__main__":
+    create_app()

--- a/examples/medium-risk-mcp-server/server.py
+++ b/examples/medium-risk-mcp-server/server.py
@@ -1,5 +1,6 @@
 """Medium-risk MCP server — limited file access surface for scoring demos."""
 
+
 def create_app():
     mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
 

--- a/examples/safe-mcp-server/server.py
+++ b/examples/safe-mcp-server/server.py
@@ -1,0 +1,15 @@
+"""Minimal low-risk MCP server for MCPAudit scoring demos."""
+
+def create_app():
+    mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
+
+    @mcp.tool()
+    def greet(name: str) -> str:
+        """Return a greeting for the given name."""
+        return f"Hello, {name}"
+
+    return mcp
+
+
+if __name__ == "__main__":
+    create_app()

--- a/examples/safe-mcp-server/server.py
+++ b/examples/safe-mcp-server/server.py
@@ -1,5 +1,6 @@
 """Minimal low-risk MCP server for MCPAudit scoring demos."""
 
+
 def create_app():
     mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
 

--- a/src/mcpaudit/cli/main.py
+++ b/src/mcpaudit/cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Annotated
 
@@ -12,6 +13,9 @@ from mcpaudit import __version__
 from mcpaudit.core.config import ScanConfig
 from mcpaudit.core.scanner import Scanner
 from mcpaudit.reporting.html import write_html_report
+from mcpaudit.ui.progress import print_scan_command, run_with_progress
+from mcpaudit.ui.report_renderer import ReportRenderer
+from mcpaudit.ui.theme import ThemeName, get_theme
 
 app = typer.Typer(
     name="mcpaudit",
@@ -51,16 +55,66 @@ def scan(
         bool,
         typer.Option("--fail-on-critical", help="Exit with code 1 if critical findings exist"),
     ] = False,
+    theme: Annotated[
+        str,
+        typer.Option(
+            "--theme",
+            help="Terminal theme: cyber, minimal, github",
+            case_sensitive=False,
+        ),
+    ] = ThemeName.CYBER.value,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
 ) -> None:
     """Run a full security scan against an MCP server."""
-    config = ScanConfig(target=target, output=output, fail_on_critical=fail_on_critical)
+    try:
+        resolved_theme = get_theme(theme)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+
+    config = ScanConfig(
+        target=target,
+        output=output,
+        fail_on_critical=fail_on_critical,
+        theme=resolved_theme.name.value,
+        no_progress=no_progress,
+    )
     scanner = Scanner(config)
-    report = scanner.run()
-    scanner.print_summary(report)
+    command = f"mcpaudit scan {target}"
+    renderer = ReportRenderer(resolved_theme, console=console)
+    term_width = renderer._terminal_width()
+
+    print_scan_command(console, resolved_theme, command, terminal_width=term_width)
+
+    def _execute_scan():
+        return scanner.run()
+
+    started = time.perf_counter()
+    report = run_with_progress(
+        _execute_scan,
+        theme=resolved_theme,
+        console=console,
+        enabled=not no_progress,
+        terminal_width=term_width,
+    )
+    duration = time.perf_counter() - started
+
+    if not no_progress:
+        console.print()
+
+    renderer.render(
+        report,
+        command=command,
+        duration_seconds=duration,
+        analyzers_run=scanner.analyzers_run_count(),
+    )
 
     if output:
         output.write_text(report.model_dump_json(indent=2))
-        console.print(f"[green]Report written to[/green] {output}")
+        renderer.render_saved_notice(str(output))
 
     if fail_on_critical and report.summary.critical > 0:
         raise typer.Exit(code=1)
@@ -76,13 +130,24 @@ def report(
         Path,
         typer.Option("--output", "-o", help="HTML report path"),
     ] = Path("security-report.html"),
+    theme: Annotated[
+        str,
+        typer.Option("--theme", help="Terminal theme: cyber, minimal, github"),
+    ] = ThemeName.CYBER.value,
 ) -> None:
     """Generate an HTML security report from scan results."""
     from mcpaudit.reporting.models import ScanReport
 
+    try:
+        resolved_theme = get_theme(theme)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+
     data = ScanReport.model_validate_json(input_file.read_text())
     write_html_report(data, output)
-    console.print(f"[green]HTML report written to[/green] {output}")
+    renderer = ReportRenderer(resolved_theme, console=console)
+    renderer.render_saved_notice(str(output))
 
 
 @app.command()

--- a/src/mcpaudit/core/config.py
+++ b/src/mcpaudit/core/config.py
@@ -16,3 +16,5 @@ class ScanConfig(BaseModel):
     enable_jailbreak: bool = True
     enable_attack_chains: bool = True
     timeout_seconds: int = Field(default=120, ge=1)
+    theme: str = "cyber"
+    no_progress: bool = False

--- a/src/mcpaudit/core/scanner.py
+++ b/src/mcpaudit/core/scanner.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from rich.console import Console
-from rich.table import Table
-
 from mcpaudit import __version__
 from mcpaudit.analyzers.attack_chains import AttackChainAnalyzer
 from mcpaudit.analyzers.data_leakage import DataLeakageAnalyzer
@@ -19,8 +16,6 @@ from mcpaudit.core.config import ScanConfig
 from mcpaudit.mcp.client import MCPClient
 from mcpaudit.reporting.models import Finding, ScanReport, ScanSummary
 from mcpaudit.scoring.engine import RiskScoringEngine
-
-console = Console()
 
 
 class Scanner:
@@ -54,6 +49,9 @@ class Scanner:
         score = self.scoring.score(findings)
         summary = ScanSummary.from_findings(findings)
 
+        if not RiskScoringEngine.verify(findings, score):
+            raise RuntimeError("Risk score does not match findings — scoring regression")
+
         return ScanReport(
             version=__version__,
             target=str(self.config.target),
@@ -64,34 +62,9 @@ class Scanner:
             score=score,
         )
 
-    def print_summary(self, report: ScanReport) -> None:
-        """Render a human-readable summary to the terminal."""
-        console.print()
-        console.rule("[bold red]MCPAudit Security Report[/bold red]")
-        console.print(f"Target: [cyan]{report.target}[/cyan]")
-        console.print(f"Overall Score: [bold]{report.score.overall}/100[/bold]")
-        console.print()
-
-        table = Table(title="Findings by Severity")
-        table.add_column("Severity", style="bold")
-        table.add_column("Count", justify="right")
-        for severity, count in [
-            ("Critical", report.summary.critical),
-            ("High", report.summary.high),
-            ("Medium", report.summary.medium),
-            ("Low", report.summary.low),
-        ]:
-            table.add_row(severity, str(count))
-        console.print(table)
-
-        if report.findings:
-            console.print()
-            for finding in report.findings[:10]:
-                console.print(
-                    f"[{finding.severity.color}]{finding.severity.value.upper()}[/]: {finding.title}"
-                )
-            if len(report.findings) > 10:
-                console.print(f"... and {len(report.findings) - 10} more findings")
+    def analyzers_run_count(self) -> int:
+        """Return the number of security analyzers executed."""
+        return sum(1 for analyzer in self.analyzers if self._is_enabled(analyzer))
 
     def _is_enabled(self, analyzer: object) -> bool:
         name = type(analyzer).__name__

--- a/src/mcpaudit/reporting/__init__.py
+++ b/src/mcpaudit/reporting/__init__.py
@@ -1,5 +1,5 @@
 """Reporting module."""
 
-from mcpaudit.reporting.models import Finding, RiskScore, ScanReport, ScanSummary, Severity
+from mcpaudit.reporting.models import Finding, RiskScore, ScanReport, ScanSummary, ScoreBasis, Severity
 
-__all__ = ["Finding", "RiskScore", "ScanReport", "ScanSummary", "Severity"]
+__all__ = ["Finding", "RiskScore", "ScanReport", "ScanSummary", "ScoreBasis", "Severity"]

--- a/src/mcpaudit/reporting/html.py
+++ b/src/mcpaudit/reporting/html.py
@@ -28,7 +28,10 @@ HTML_TEMPLATE = Template("""<!DOCTYPE html>
 <body>
   <h1>MCPAudit Security Report</h1>
   <p class="meta">Target: {{ report.target }} · Scanned: {{ report.scanned_at }}</p>
-  <p class="score">Score: {{ report.score.overall }}/100</p>
+  <p class="score">
+    Security Score: {{ report.score.overall }}/100 ·
+    Risk Index: {{ report.score.risk_index }}/100
+  </p>
   <p>
     Critical: {{ report.summary.critical }} ·
     High: {{ report.summary.high }} ·

--- a/src/mcpaudit/reporting/models.py
+++ b/src/mcpaudit/reporting/models.py
@@ -59,9 +59,28 @@ class ScanSummary(BaseModel):
         )
 
 
+class ScoreBasis(BaseModel):
+    """Severity counts used to compute the score (auditable, not hardcoded)."""
+
+    critical: int = Field(ge=0)
+    high: int = Field(ge=0)
+    medium: int = Field(ge=0)
+    low: int = Field(ge=0)
+    scorable_total: int = Field(ge=0)
+    excluded_non_scorable: int = Field(
+        ge=0,
+        description="Findings excluded from scoring (e.g. compliance meta-checks)",
+    )
+
+
 class RiskScore(BaseModel):
-    overall: int = Field(ge=0, le=100)
-    penalty: int = Field(ge=0)
+    """overall: security score (100 = best). risk_index: inverted risk (100 = worst)."""
+
+    overall: int = Field(ge=0, le=100, description="Security score; higher is better")
+    risk_index: int = Field(ge=0, le=100, description="Risk index; higher is worse")
+    raw_risk: int = Field(ge=0, description="Uncapped weighted risk points")
+    penalty: int = Field(ge=0, description="Deprecated alias for raw_risk")
+    basis: ScoreBasis = Field(description="Finding counts used for this score")
 
 
 class ScanReport(BaseModel):

--- a/src/mcpaudit/scoring/engine.py
+++ b/src/mcpaudit/scoring/engine.py
@@ -2,20 +2,76 @@
 
 from __future__ import annotations
 
-from mcpaudit.reporting.models import Finding, RiskScore, Severity
+import math
 
-SEVERITY_WEIGHTS = {
+from mcpaudit.reporting.models import Finding, RiskScore, ScanSummary, ScoreBasis, Severity
+
+# Weights for raw risk index (higher = more risk).
+RISK_WEIGHTS: dict[Severity, int] = {
     Severity.CRITICAL: 25,
     Severity.HIGH: 10,
-    Severity.MEDIUM: 4,
+    Severity.MEDIUM: 3,
     Severity.LOW: 1,
 }
 
+# Exponential decay scale: score = 100 * exp(-raw_risk / RISK_DECAY_SCALE)
+RISK_DECAY_SCALE = 50.0
+
+# Meta-findings from compliance checks should not affect scoring.
+NON_SCORING_ANALYZERS = frozenset({"compliance"})
+
 
 class RiskScoringEngine:
-    """Computes an overall security score inspired by CVSS and OWASP risk rating."""
+    """Computes security score (higher is better) and risk index (higher is worse)."""
 
     def score(self, findings: list[Finding]) -> RiskScore:
-        penalty = sum(SEVERITY_WEIGHTS[f.severity] for f in findings)
-        overall = max(0, 100 - penalty)
-        return RiskScore(overall=overall, penalty=penalty)
+        """Derive all score fields from the findings list — nothing is hardcoded."""
+        scorable, excluded = _partition_findings(findings)
+        summary = ScanSummary.from_findings(scorable)
+        raw_risk = raw_risk_from_summary(summary)
+        overall = security_score_from_raw_risk(raw_risk)
+        risk_index = min(100, raw_risk)
+
+        return RiskScore(
+            overall=overall,
+            risk_index=risk_index,
+            raw_risk=raw_risk,
+            penalty=raw_risk,
+            basis=ScoreBasis(
+                critical=summary.critical,
+                high=summary.high,
+                medium=summary.medium,
+                low=summary.low,
+                scorable_total=summary.total,
+                excluded_non_scorable=excluded,
+            ),
+        )
+
+    @staticmethod
+    def verify(findings: list[Finding], computed: RiskScore) -> bool:
+        """Return True if ``computed`` matches a fresh calculation from ``findings``."""
+        return RiskScoringEngine().score(findings) == computed
+
+
+def _partition_findings(findings: list[Finding]) -> tuple[list[Finding], int]:
+    scorable = [f for f in findings if f.analyzer not in NON_SCORING_ANALYZERS]
+    excluded = len(findings) - len(scorable)
+    return scorable, excluded
+
+
+def raw_risk_from_summary(summary: ScanSummary) -> int:
+    """Linear risk points from severity counts."""
+    return (
+        summary.critical * RISK_WEIGHTS[Severity.CRITICAL]
+        + summary.high * RISK_WEIGHTS[Severity.HIGH]
+        + summary.medium * RISK_WEIGHTS[Severity.MEDIUM]
+        + summary.low * RISK_WEIGHTS[Severity.LOW]
+    )
+
+
+def security_score_from_raw_risk(raw_risk: int) -> int:
+    """Exponential decay security score."""
+    if raw_risk <= 0:
+        return 100
+    value = 100.0 * math.exp(-raw_risk / RISK_DECAY_SCALE)
+    return max(0, min(100, round(value)))

--- a/src/mcpaudit/ui/__init__.py
+++ b/src/mcpaudit/ui/__init__.py
@@ -1,0 +1,6 @@
+"""Terminal UI components for MCPAudit."""
+
+from mcpaudit.ui.report_renderer import ReportRenderer
+from mcpaudit.ui.theme import ThemeName, get_theme
+
+__all__ = ["ReportRenderer", "ThemeName", "get_theme"]

--- a/src/mcpaudit/ui/dashboard.py
+++ b/src/mcpaudit/ui/dashboard.py
@@ -1,0 +1,340 @@
+"""Dashboard layout components for scan reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich import box
+from rich.columns import Columns
+from rich.console import Group, RenderableType
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from mcpaudit.reporting.models import Finding, ScanReport, ScanSummary, ScoreBasis, Severity
+from mcpaudit.scoring.engine import RISK_WEIGHTS, security_score_from_raw_risk
+from mcpaudit.ui.layout import FINDINGS_PANEL_MIN_WIDTH, SEVERITY_PANEL_WIDTH, content_width
+from mcpaudit.ui.theme import SEVERITY_ORDER, Theme
+
+OWASP_CATALOG: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("LLM01", "Prompt Injection", ("prompt_injection",)),
+    ("LLM02", "Sensitive Information Disclosure", ("data_leakage",)),
+    ("LLM04", "Model Denial of Service", ("tool_abuse",)),
+    ("LLM06", "Excessive Agency", ("attack_chains", "permission_analyzer", "compliance")),
+    ("LLM07", "System Prompt Leakage", ("jailbreak",)),
+    ("LLM08", "Vector and Embedding Weaknesses", ()),
+)
+
+TOP_FINDINGS_LIMIT = 8
+
+
+@dataclass(frozen=True)
+class ScanDisplayMeta:
+    """Metadata for terminal dashboard rendering."""
+
+    command: str
+    duration_seconds: float
+    analyzers_run: int
+
+
+def sort_findings(findings: list[Finding]) -> list[Finding]:
+    """Sort findings by severity (stable order within same severity)."""
+    return sorted(findings, key=lambda f: SEVERITY_ORDER[f.severity])
+
+
+def compute_owasp_counts(findings: list[Finding]) -> list[tuple[str, str, int]]:
+    """Map findings to OWASP LLM categories with counts."""
+    counts: dict[str, int] = {}
+    labels: dict[str, str] = {}
+    for owasp_id, label, analyzers in OWASP_CATALOG:
+        labels[owasp_id] = label
+        matched = sum(1 for f in findings if f.analyzer in analyzers)
+        if matched:
+            counts[owasp_id] = matched
+
+    return [
+        (owasp_id, labels[owasp_id], count)
+        for owasp_id, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def build_scan_status(meta: ScanDisplayMeta, report: ScanReport, theme: Theme) -> Table:
+    """Build scan complete status block with aligned metrics."""
+    p = theme.palette
+    grid = Table.grid(padding=(0, 1))
+    grid.add_column(
+        style=theme.style(p.grey),
+        justify="left",
+        no_wrap=True,
+        width=18,
+    )
+    grid.add_column(style=theme.style(p.white), justify="left", overflow="fold")
+
+    grid.add_row(
+        Text("✓ Scan Complete", style=theme.style(p.green, bold=True)),
+        "",
+    )
+    grid.add_row("Target:", report.target)
+    grid.add_row("Scan Time:", f"{max(meta.duration_seconds, 0.01):.2f}s")
+    grid.add_row("Tools Discovered:", str(len(report.server.tools)))
+    grid.add_row("Analyzers Run:", str(meta.analyzers_run))
+    return grid
+
+
+REPORT_DIVIDER = "=" * 20 + " MCPAudit Security Report " + "=" * 20
+
+
+def build_report_divider(theme: Theme) -> Text:
+    """Security report divider (fixed width for consistent screenshots)."""
+    return Text(REPORT_DIVIDER, style=theme.style(theme.palette.white, bold=True))
+
+
+def _format_score_formula(basis: ScoreBasis, raw_risk: int) -> str:
+    """Human-readable formula from score basis counts."""
+    parts: list[str] = []
+    if basis.critical:
+        parts.append(f"{basis.critical}×{RISK_WEIGHTS[Severity.CRITICAL]}")
+    if basis.high:
+        parts.append(f"{basis.high}×{RISK_WEIGHTS[Severity.HIGH]}")
+    if basis.medium:
+        parts.append(f"{basis.medium}×{RISK_WEIGHTS[Severity.MEDIUM]}")
+    if basis.low:
+        parts.append(f"{basis.low}×{RISK_WEIGHTS[Severity.LOW]}")
+    if not parts:
+        return "0 risk points"
+    return " + ".join(parts) + f" = {raw_risk}"
+
+
+def build_score_block(report: ScanReport, theme: Theme) -> Table:
+    """Security score and risk index derived from report findings."""
+    p = theme.palette
+    basis = report.score.basis
+    rating, score_color = theme.score_rating(report.score.overall)
+    risk_color = theme.risk_index_color(report.score.risk_index)
+    expected = security_score_from_raw_risk(report.score.raw_risk)
+
+    grid = Table.grid(padding=(0, 1))
+    grid.add_column(style=theme.style(p.white, bold=True), width=16, no_wrap=True)
+    grid.add_column(justify="left")
+
+    grid.add_row(
+        "Overall Score:",
+        Text(f"{report.score.overall}/100 ({rating})", style=theme.style(score_color, bold=True)),
+    )
+    grid.add_row(
+        "Risk Index:",
+        Text(f"{report.score.risk_index}/100", style=theme.style(risk_color, bold=True)),
+    )
+    grid.add_row(
+        "Scoring basis:",
+        Text(
+            f"{basis.critical} Critical, {basis.high} High, "
+            f"{basis.medium} Medium, {basis.low} Low "
+            f"({basis.scorable_total} scorable findings)",
+            style=theme.style(p.white),
+        ),
+    )
+    if basis.excluded_non_scorable:
+        grid.add_row(
+            "",
+            Text(
+                f"{basis.excluded_non_scorable} compliance meta-finding(s) "
+                "shown in report but excluded from score",
+                style=theme.style(p.grey, dim=True),
+            ),
+        )
+    grid.add_row(
+        "Formula:",
+        Text(_format_score_formula(basis, report.score.raw_risk), style=theme.style(p.cyan)),
+    )
+    grid.add_row(
+        "",
+        Text(
+            f"Security score = round(100 × e^(-{report.score.raw_risk}/50)) → {expected}",
+            style=theme.style(p.grey, dim=True),
+        ),
+    )
+    return grid
+
+
+def build_severity_panel(summary: ScanSummary, theme: Theme) -> Panel:
+    """Left panel: severity breakdown with colored bullets."""
+    p = theme.palette
+    table = Table(
+        box=box.SIMPLE_HEAD,
+        show_header=True,
+        header_style=theme.style(p.grey, bold=True),
+        border_style=p.panel_border,
+        expand=False,
+        padding=(0, 1),
+    )
+    table.add_column("Severity", width=14, no_wrap=True)
+    table.add_column("Count", width=5, justify="right")
+
+    rows = [
+        (Severity.CRITICAL, summary.critical, "● Critical"),
+        (Severity.HIGH, summary.high, "● High"),
+        (Severity.MEDIUM, summary.medium, "● Medium"),
+        (Severity.LOW, summary.low, "● Low"),
+    ]
+    for severity, count, label in rows:
+        color = theme.severity_color(severity)
+        table.add_row(
+            Text(label, style=theme.style(color, bold=True)),
+            str(count),
+        )
+
+    return Panel(
+        table,
+        title=f"[bold {p.cyan}]Severity Summary[/]",
+        title_align="left",
+        border_style=p.panel_border,
+        width=SEVERITY_PANEL_WIDTH,
+        padding=(0, 1),
+    )
+
+
+def _format_finding_line(index: int, finding: Finding, theme: Theme, wrap_width: int) -> Text:
+    """Format a single top finding entry with optional title wrap."""
+    p = theme.palette
+    sev_color = theme.severity_color(finding.severity)
+    sev_label = theme.severity_label(finding.severity)
+    indent = " " * 12
+    first_line_budget = max(wrap_width - 12, 20)
+    title = finding.title
+
+    line = Text()
+    line.append(f"[{index}] ", style=theme.style(p.grey, dim=True))
+    line.append(f"{sev_label:<8}", style=theme.style(sev_color, bold=True))
+
+    if len(title) <= first_line_budget:
+        line.append(f" {title}", style=theme.style(p.white))
+        return line
+
+    split_at = title.rfind(" ", 0, first_line_budget)
+    if split_at <= 0:
+        split_at = first_line_budget
+    line.append(f" {title[:split_at]}", style=theme.style(p.white))
+    remainder = title[split_at:].lstrip()
+    if remainder:
+        line.append("\n")
+        line.append(f"{indent}{remainder}", style=theme.style(p.white))
+    return line
+
+
+def build_top_findings_panel(findings: list[Finding], theme: Theme, panel_width: int) -> Panel:
+    """Right panel: ranked top findings."""
+    p = theme.palette
+    sorted_findings = sort_findings(findings)
+    shown = sorted_findings[:TOP_FINDINGS_LIMIT]
+    wrap_width = max(28, panel_width - 6)
+
+    body = Text()
+    for idx, finding in enumerate(shown, start=1):
+        if idx > 1:
+            body.append("\n")
+        body.append_text(_format_finding_line(idx, finding, theme, wrap_width))
+
+    remaining = len(sorted_findings) - len(shown)
+    if remaining > 0:
+        body.append("\n")
+        body.append(f"\n...and {remaining} more findings", style=theme.style(p.grey, dim=True))
+
+    return Panel(
+        body if shown else Text("No findings detected.", style=theme.style(p.green)),
+        title=f"[bold {p.cyan}]Top Findings[/]",
+        title_align="left",
+        border_style=p.panel_border,
+        width=panel_width,
+        padding=(0, 1),
+    )
+
+
+def build_owasp_section(findings: list[Finding], theme: Theme) -> RenderableType:
+    """OWASP LLM Top 10 mapping block."""
+    p = theme.palette
+    owasp_counts = compute_owasp_counts(findings)
+    if not owasp_counts:
+        return Text("No OWASP mappings available.", style=theme.style(p.grey, dim=True))
+
+    max_count = max(count for _, _, count in owasp_counts)
+    header = Text("OWASP LLM Top 10 Mapping\n", style=theme.style(p.blue, bold=True))
+
+    lines = Text()
+    for owasp_id, label, count in owasp_counts:
+        short_label = label.replace(" Disclosure", "")
+        if len(short_label) > 28:
+            short_label = short_label[:25] + "..."
+        count_color = theme.owasp_count_color(count, max_count)
+        lines.append("• ", style=theme.style(p.cyan))
+        lines.append(f"{owasp_id}: {short_label:<28}", style=theme.style(p.white))
+        lines.append(f" ({count})\n", style=theme.style(count_color, bold=True))
+
+    return Group(header, lines)
+
+
+def build_footer_tip(theme: Theme) -> RenderableType:
+    """Footer tip with command hints."""
+    p = theme.palette
+    tip = Text()
+    tip.append("💡 ", style=theme.style(p.tip_icon))
+    tip.append("Tip: ", style=theme.style(p.grey, bold=True))
+    tip.append("Save detailed report with ", style=theme.style(p.muted))
+    tip.append("-o report.json", style=theme.style(p.command, bold=True))
+    tip.append("\n     or generate HTML report with ", style=theme.style(p.muted))
+    tip.append("'mcpaudit report <file>'", style=theme.style(p.command, bold=True))
+    return tip
+
+
+def build_dashboard(
+    report: ScanReport,
+    meta: ScanDisplayMeta,
+    theme: Theme,
+    *,
+    terminal_width: int,
+) -> RenderableType:
+    """Assemble full dashboard as a single fixed-width renderable."""
+    width = content_width(terminal_width)
+    findings_width = max(FINDINGS_PANEL_MIN_WIDTH, width - SEVERITY_PANEL_WIDTH - 2)
+
+    blocks: list[RenderableType] = [
+        build_scan_status(meta, report, theme),
+        build_report_divider(theme),
+        build_score_block(report, theme),
+    ]
+
+    if width >= 90:
+        blocks.append(
+            Columns(
+                [
+                    build_severity_panel(report.summary, theme),
+                    build_top_findings_panel(report.findings, theme, findings_width),
+                ],
+                width=width,
+                expand=False,
+                equal=False,
+                padding=0,
+            )
+        )
+    else:
+        blocks.extend(
+            [
+                build_severity_panel(report.summary, theme),
+                build_top_findings_panel(report.findings, theme, width - 4),
+            ]
+        )
+
+    blocks.extend(
+        [
+            Panel(
+                build_owasp_section(report.findings, theme),
+                border_style=theme.palette.panel_border,
+                width=width,
+                padding=(0, 1),
+            ),
+            build_report_divider(theme),
+            build_footer_tip(theme),
+        ]
+    )
+
+    return Group(*blocks)

--- a/src/mcpaudit/ui/layout.py
+++ b/src/mcpaudit/ui/layout.py
@@ -1,0 +1,30 @@
+"""Layout helpers for fixed-width terminal dashboards."""
+
+from __future__ import annotations
+
+from rich.align import Align
+from rich.console import RenderableType
+
+# Keep dashboard readable on ultra-wide terminals (IDE panes often report 150–200+ cols).
+CONTENT_MAX_WIDTH = 100
+CONTENT_MIN_WIDTH = 72
+SEVERITY_PANEL_WIDTH = 34
+FINDINGS_PANEL_MIN_WIDTH = 52
+
+
+def content_width(terminal_width: int) -> int:
+    """Clamp layout width for a balanced dashboard on any terminal size."""
+    return max(CONTENT_MIN_WIDTH, min(terminal_width, CONTENT_MAX_WIDTH))
+
+
+def center_in_terminal(
+    renderable: RenderableType,
+    *,
+    content_width: int,
+    terminal_width: int,
+) -> RenderableType:
+    """Center a fixed-width block inside a possibly wider terminal."""
+    inner = Align.center(renderable, width=content_width)
+    if terminal_width <= content_width:
+        return inner
+    return Align.center(inner, width=terminal_width)

--- a/src/mcpaudit/ui/logo.py
+++ b/src/mcpaudit/ui/logo.py
@@ -1,0 +1,105 @@
+"""ASCII logo and header rendering."""
+
+from __future__ import annotations
+
+import sys
+
+from rich.console import Console, Group, RenderableType
+from rich.text import Text
+
+from mcpaudit import __version__
+from mcpaudit.ui.layout import center_in_terminal, content_width
+from mcpaudit.ui.theme import Theme
+
+# Unicode block-letter logo (64 cols wide).
+MCPAUDIT_ASCII = r"""
+███╗   ███╗ ██████╗██████╗  █████╗ ██╗   ██╗██████╗ ██╗████████╗
+████╗ ████║██╔════╝██╔══██╗██╔══██╗██║   ██║██╔══██╗██║╚══██╔══╝
+██╔████╔██║██║     ██████╔╝███████║██║   ██║██║  ██║██║   ██║
+██║╚██╔╝██║██║     ██╔═══╝ ██╔══██║██║   ██║██║  ██║██║   ██║
+██║ ╚═╝ ██║╚██████╗██║     ██║  ██║╚██████╔╝██████╔╝██║   ██║
+╚═╝     ╚═╝ ╚═════╝╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝   ╚═╝
+""".strip(
+    "\n"
+)
+
+# Pure-ASCII fallback when Unicode block chars cannot be encoded.
+MCPAUDIT_ASCII_PLAIN = r"""
+ __  __  ____  ____   _    _   _ _____ ___ _____ _____ 
+|  \/  |/ ___||  _ \ / \  | | | |_   _|_ _|_   _| ____|
+| |\/| | |    | |_) / _ \ | | | | | |  | |  | | |  _|  
+| |  | | |___ |  __/ ___ \| |_| | | |  | |  | | | |___ 
+|_|  |_|\____||_| /_/   \_\\___/  |_| |___| |_| |_____|
+""".strip(
+    "\n"
+)
+
+LOGO_WIDTH = max(len(line) for line in MCPAUDIT_ASCII.splitlines())
+LOGO_MIN_TERMINAL_WIDTH = LOGO_WIDTH + 4
+
+
+def _stdout_supports_unicode_logo() -> bool:
+    """Return True if the logo can be encoded for this stdout."""
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        MCPAUDIT_ASCII.encode(encoding)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
+def build_logo_text(theme: Theme, *, use_unicode: bool = True) -> Text:
+    """Build gradient-styled ASCII logo."""
+    art = MCPAUDIT_ASCII if use_unicode else MCPAUDIT_ASCII_PLAIN
+    lines = art.splitlines()
+    gradient = theme.palette.logo_gradient
+    text = Text()
+    for line_idx, line in enumerate(lines):
+        if line_idx:
+            text.append("\n")
+        for char_idx, char in enumerate(line):
+            if char == " ":
+                text.append(char)
+            else:
+                color = gradient[char_idx % len(gradient)]
+                text.append(char, style=theme.style(color, bold=True))
+    return text
+
+
+def render_header(
+    console: Console,
+    theme: Theme,
+    *,
+    terminal_width: int | None = None,
+) -> None:
+    """Render logo, tagline, version, and optional command echo."""
+    term_width = terminal_width or console.width
+    layout_width = content_width(term_width)
+    use_unicode = _stdout_supports_unicode_logo()
+
+    header_parts: list[RenderableType] = []
+
+    logo = build_logo_text(theme, use_unicode=use_unicode and layout_width >= LOGO_MIN_TERMINAL_WIDTH)
+    header_parts.append(logo)
+    header_parts.append(
+        Text(
+            "The Security Linter for Model Context Protocol Servers",
+            style=theme.style(theme.palette.subtitle, bold=True),
+            justify="center",
+        )
+    )
+    header_parts.append(
+        Text(
+            f"v{__version__}-alpha",
+            style=theme.style(theme.palette.grey, dim=True),
+            justify="center",
+        )
+    )
+
+    console.print(
+        center_in_terminal(
+            Group(*header_parts),
+            content_width=layout_width,
+            terminal_width=term_width,
+        )
+    )

--- a/src/mcpaudit/ui/logo.py
+++ b/src/mcpaudit/ui/logo.py
@@ -19,9 +19,7 @@ MCPAUDIT_ASCII = r"""
 ██║╚██╔╝██║██║     ██╔═══╝ ██╔══██║██║   ██║██║  ██║██║   ██║
 ██║ ╚═╝ ██║╚██████╗██║     ██║  ██║╚██████╔╝██████╔╝██║   ██║
 ╚═╝     ╚═╝ ╚═════╝╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝   ╚═╝
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 # Pure-ASCII fallback when Unicode block chars cannot be encoded.
 MCPAUDIT_ASCII_PLAIN = r"""
@@ -30,9 +28,7 @@ MCPAUDIT_ASCII_PLAIN = r"""
 | |\/| | |    | |_) / _ \ | | | | | |  | |  | | |  _|  
 | |  | | |___ |  __/ ___ \| |_| | | |  | |  | | | |___ 
 |_|  |_|\____||_| /_/   \_\\___/  |_| |___| |_| |_____|
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 LOGO_WIDTH = max(len(line) for line in MCPAUDIT_ASCII.splitlines())
 LOGO_MIN_TERMINAL_WIDTH = LOGO_WIDTH + 4

--- a/src/mcpaudit/ui/progress.py
+++ b/src/mcpaudit/ui/progress.py
@@ -1,0 +1,104 @@
+"""Hacker-style scan progress animation."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+from rich.console import Console
+from rich.text import Text
+
+from mcpaudit.ui.layout import content_width
+from mcpaudit.ui.theme import Theme
+
+T = TypeVar("T")
+
+SCAN_PHASES = (
+    "Discovering tools",
+    "Mapping permissions",
+    "Detecting attack chains",
+    "Generating report",
+)
+
+SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+
+def print_scan_command(console: Console, theme: Theme, command: str, *, terminal_width: int) -> None:
+    """Echo the scan command in terminal style."""
+    p = theme.palette
+    text = Text()
+    text.append("$ ", style=theme.style(p.green, bold=True))
+    text.append(command, style=theme.style(p.cyan))
+    console.print(text, width=content_width(terminal_width))
+
+
+def _phase_line(theme: Theme, phase: str, *, done: bool, frame: str = "·") -> Text:
+    p = theme.palette
+    line = Text()
+    line.append("[", style=theme.style(p.grey))
+    if done:
+        line.append("✓", style=theme.style(p.green, bold=True))
+    else:
+        line.append(frame, style=theme.style(p.cyan, bold=True))
+    line.append("] ", style=theme.style(p.grey))
+    line.append(f"{phase}...", style=theme.style(p.white if done else p.cyan))
+    return line
+
+
+def run_with_progress(
+    work: Callable[[], T],
+    *,
+    theme: Theme,
+    console: Console | None = None,
+    enabled: bool = True,
+    min_duration: float = 1.2,
+    terminal_width: int = 100,
+) -> T:
+    """Run scan work with sequential [✓] phase lines before the dashboard."""
+    if not enabled:
+        return work()
+
+    term_console = console or Console()
+    width = content_width(terminal_width)
+    result: list[T] = []
+    error: list[BaseException] = []
+    done = threading.Event()
+
+    def _runner() -> None:
+        try:
+            result.append(work())
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+
+    phase_duration = max(min_duration / len(SCAN_PHASES), 0.28)
+    frame_idx = 0
+
+    for index, phase in enumerate(SCAN_PHASES):
+        phase_start = time.monotonic()
+        is_last = index == len(SCAN_PHASES) - 1
+
+        while True:
+            elapsed = time.monotonic() - phase_start
+            frame = SPINNER_FRAMES[frame_idx % len(SPINNER_FRAMES)]
+            frame_idx += 1
+            term_console.print(_phase_line(theme, phase, done=False, frame=frame), width=width, end="\r")
+
+            if done.is_set() and (elapsed >= phase_duration * 0.5 or is_last):
+                break
+            if elapsed >= phase_duration and not is_last:
+                break
+            time.sleep(0.07)
+
+        term_console.print(_phase_line(theme, phase, done=True), width=width)
+
+    thread.join()
+    if error:
+        raise error[0]
+    return result[0]

--- a/src/mcpaudit/ui/report_renderer.py
+++ b/src/mcpaudit/ui/report_renderer.py
@@ -1,0 +1,81 @@
+"""Main terminal report renderer."""
+
+from __future__ import annotations
+
+import shutil
+
+from rich.console import Console
+
+from mcpaudit.reporting.models import ScanReport
+from mcpaudit.ui.dashboard import ScanDisplayMeta, build_dashboard
+from mcpaudit.ui.layout import center_in_terminal, content_width
+from mcpaudit.ui.logo import LOGO_MIN_TERMINAL_WIDTH, render_header
+from mcpaudit.ui.theme import Theme, get_theme
+
+
+class ReportRenderer:
+    """Renders scan reports to the terminal using Rich."""
+
+    def __init__(
+        self,
+        theme: str | Theme = "cyber",
+        *,
+        console: Console | None = None,
+    ) -> None:
+        resolved = theme if isinstance(theme, Theme) else get_theme(theme)
+        self.theme = resolved
+        self.console = console or Console(highlight=False)
+
+    def render(
+        self,
+        report: ScanReport,
+        *,
+        command: str | None = None,
+        duration_seconds: float = 0.0,
+        analyzers_run: int = 6,
+    ) -> None:
+        """Render the full cybersecurity terminal dashboard."""
+        del command  # command is printed during the scan animation phase
+        meta = ScanDisplayMeta(
+            command="",
+            duration_seconds=duration_seconds,
+            analyzers_run=analyzers_run,
+        )
+        term_width = self._terminal_width()
+        layout_width = content_width(term_width)
+
+        render_header(
+            self.console,
+            self.theme,
+            terminal_width=term_width,
+        )
+
+        dashboard = build_dashboard(
+            report,
+            meta,
+            self.theme,
+            terminal_width=term_width,
+        )
+        self.console.print(
+            center_in_terminal(
+                dashboard,
+                content_width=layout_width,
+                terminal_width=term_width,
+            )
+        )
+
+    def _terminal_width(self) -> int:
+        """Best-effort terminal width (IDE terminals often misreport via Rich alone)."""
+        try:
+            return max(self.console.width, shutil.get_terminal_size().columns)
+        except OSError:
+            return max(self.console.width, LOGO_MIN_TERMINAL_WIDTH)
+
+    def render_saved_notice(self, path: str) -> None:
+        """Themed notice when JSON report is written."""
+        p = self.theme.palette
+        self.console.print(
+            f"[{self.theme.style(p.green, bold=True)}]✓[/] "
+            f"[{self.theme.style(p.muted)}]Report written to[/] "
+            f"[{self.theme.style(p.command, bold=True)}]{path}[/]",
+        )

--- a/src/mcpaudit/ui/theme.py
+++ b/src/mcpaudit/ui/theme.py
@@ -1,0 +1,172 @@
+"""Terminal color themes for MCPAudit CLI output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from mcpaudit.reporting.models import Severity
+
+
+class ThemeName(StrEnum):
+    CYBER = "cyber"
+    MINIMAL = "minimal"
+    GITHUB = "github"
+
+
+@dataclass(frozen=True)
+class ThemePalette:
+    """Color palette for terminal rendering."""
+
+    cyan: str
+    blue: str
+    red: str
+    orange: str
+    yellow: str
+    green: str
+    grey: str
+    white: str
+    panel_border: str
+    logo_gradient: tuple[str, ...]
+    subtitle: str
+    divider: str
+    tip_icon: str
+    command: str
+    muted: str
+
+
+CYBER_PALETTE = ThemePalette(
+    cyan="#00bfff",
+    blue="#0099ff",
+    red="#ff4d4f",
+    orange="#ff8c00",
+    yellow="#ffd43b",
+    green="#2ecc71",
+    grey="#8b949e",
+    white="#f0f6fc",
+    panel_border="#0099ff",
+    logo_gradient=("#00bfff", "#0099ff", "#0077cc"),
+    subtitle="#00bfff",
+    divider="#f0f6fc",
+    tip_icon="#ffd43b",
+    command="#00bfff",
+    muted="#8b949e",
+)
+
+MINIMAL_PALETTE = ThemePalette(
+    cyan="#d0d0d0",
+    blue="#a8a8a8",
+    red="#ff6b6b",
+    orange="#e0a060",
+    yellow="#d4c46a",
+    green="#7dce94",
+    grey="#8b8b8b",
+    white="#f5f5f5",
+    panel_border="#666666",
+    logo_gradient=("#f5f5f5", "#d0d0d0", "#a8a8a8"),
+    subtitle="#d0d0d0",
+    divider="#f5f5f5",
+    tip_icon="#d4c46a",
+    command="#d0d0d0",
+    muted="#8b8b8b",
+)
+
+GITHUB_PALETTE = ThemePalette(
+    cyan="#58a6ff",
+    blue="#388bfd",
+    red="#f85149",
+    orange="#db6d28",
+    yellow="#d29922",
+    green="#3fb950",
+    grey="#8b949e",
+    white="#f0f6fc",
+    panel_border="#30363d",
+    logo_gradient=("#58a6ff", "#388bfd", "#1f6feb"),
+    subtitle="#58a6ff",
+    divider="#f0f6fc",
+    tip_icon="#d29922",
+    command="#58a6ff",
+    muted="#8b949e",
+)
+
+THEMES: dict[ThemeName, ThemePalette] = {
+    ThemeName.CYBER: CYBER_PALETTE,
+    ThemeName.MINIMAL: MINIMAL_PALETTE,
+    ThemeName.GITHUB: GITHUB_PALETTE,
+}
+
+SEVERITY_ORDER = {
+    Severity.CRITICAL: 0,
+    Severity.HIGH: 1,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 3,
+}
+
+
+@dataclass
+class Theme:
+    """Resolved theme with style helpers."""
+
+    name: ThemeName
+    palette: ThemePalette
+
+    def style(self, color: str, *, bold: bool = False, dim: bool = False) -> str:
+        parts = []
+        if bold:
+            parts.append("bold")
+        if dim:
+            parts.append("dim")
+        parts.append(color)
+        return " ".join(parts)
+
+    def severity_color(self, severity: Severity) -> str:
+        mapping = {
+            Severity.CRITICAL: self.palette.red,
+            Severity.HIGH: self.palette.orange,
+            Severity.MEDIUM: self.palette.yellow,
+            Severity.LOW: self.palette.green,
+        }
+        return mapping[severity]
+
+    def severity_label(self, severity: Severity) -> str:
+        return severity.value.upper()
+
+    def score_rating(self, score: int) -> tuple[str, str]:
+        if score >= 90:
+            return "LOW", self.palette.green
+        if score >= 70:
+            return "ELEVATED", self.palette.yellow
+        if score >= 40:
+            return "HIGH", self.palette.orange
+        return "CRITICAL", self.palette.red
+
+    def risk_index_color(self, risk_index: int) -> str:
+        if risk_index >= 75:
+            return self.palette.red
+        if risk_index >= 50:
+            return self.palette.orange
+        if risk_index >= 25:
+            return self.palette.yellow
+        return self.palette.green
+
+    def owasp_count_color(self, count: int, max_count: int) -> str:
+        if max_count == 0:
+            return self.palette.grey
+        ratio = count / max_count
+        if ratio >= 0.75:
+            return self.palette.red
+        if ratio >= 0.5:
+            return self.palette.orange
+        if ratio >= 0.25:
+            return self.palette.yellow
+        return self.palette.cyan
+
+
+def get_theme(name: str) -> Theme:
+    """Resolve a theme name to a Theme instance."""
+    try:
+        theme_name = ThemeName(name.lower())
+    except ValueError as exc:
+        valid = ", ".join(t.value for t in ThemeName)
+        raise ValueError(f"Unknown theme {name!r}. Choose from: {valid}") from exc
+    return Theme(name=theme_name, palette=THEMES[theme_name])

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,11 @@
+"""Tests for layout width helpers."""
+
+from mcpaudit.ui.layout import CONTENT_MAX_WIDTH, content_width
+
+
+def test_content_width_clamps_wide_terminal() -> None:
+    assert content_width(200) == CONTENT_MAX_WIDTH
+
+
+def test_content_width_respects_narrow_terminal() -> None:
+    assert content_width(80) == 80

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,11 +1,28 @@
 """Tests for risk scoring."""
 
-from mcpaudit.reporting.models import Finding, Severity
-from mcpaudit.scoring.engine import RiskScoringEngine
+from pathlib import Path
+
+import pytest
+
+from mcpaudit.core.config import ScanConfig
+from mcpaudit.core.scanner import Scanner
+from mcpaudit.reporting.models import Finding, ScanReport, Severity
+from mcpaudit.scoring.engine import (
+    RISK_WEIGHTS,
+    RiskScoringEngine,
+    security_score_from_raw_risk,
+)
 
 
-def test_score_decreases_with_severity() -> None:
-    engine = RiskScoringEngine()
+def test_perfect_score_no_findings() -> None:
+    score = RiskScoringEngine().score([])
+    assert score.overall == 100
+    assert score.risk_index == 0
+    assert score.raw_risk == 0
+    assert score.basis.scorable_total == 0
+
+
+def test_single_critical_exponential_score() -> None:
     findings = [
         Finding(
             id="1",
@@ -16,6 +33,131 @@ def test_score_decreases_with_severity() -> None:
             recommendation="fix",
         )
     ]
-    score = engine.score(findings)
-    assert score.overall == 75
-    assert score.penalty == 25
+    score = RiskScoringEngine().score(findings)
+    expected = security_score_from_raw_risk(25)
+    assert score.raw_risk == 25
+    assert score.risk_index == 25
+    assert score.overall == expected
+    assert score.basis.critical == 1
+    assert 50 < score.overall < 65
+
+
+def test_compliance_findings_do_not_affect_score() -> None:
+    findings = [
+        Finding(
+            id="1",
+            analyzer="permission_analyzer",
+            title="Critical",
+            description="d",
+            severity=Severity.CRITICAL,
+            recommendation="fix",
+        ),
+        Finding(
+            id="2",
+            analyzer="compliance",
+            title="Quality gate failed",
+            description="d",
+            severity=Severity.CRITICAL,
+            recommendation="fix",
+        ),
+    ]
+    score = RiskScoringEngine().score(findings)
+    assert score.raw_risk == 25
+    assert score.basis.critical == 1
+    assert score.basis.excluded_non_scorable == 1
+    assert score.overall == security_score_from_raw_risk(25)
+
+
+def test_many_criticals_differentiate_scores() -> None:
+    engine = RiskScoringEngine()
+    four = engine.score(
+        [
+            Finding(
+                id=str(i),
+                analyzer="test",
+                title="c",
+                description="d",
+                severity=Severity.CRITICAL,
+                recommendation="fix",
+            )
+            for i in range(4)
+        ]
+    )
+    ten = engine.score(
+        [
+            Finding(
+                id=str(i),
+                analyzer="test",
+                title="c",
+                description="d",
+                severity=Severity.CRITICAL,
+                recommendation="fix",
+            )
+            for i in range(10)
+        ]
+    )
+    assert four.overall > ten.overall
+    assert four.raw_risk == 100
+    assert ten.raw_risk == 250
+    assert ten.overall < four.overall
+
+
+def test_verify_detects_tampered_score() -> None:
+    findings = [
+        Finding(
+            id="1",
+            analyzer="test",
+            title="High",
+            description="d",
+            severity=Severity.HIGH,
+            recommendation="fix",
+        )
+    ]
+    real = RiskScoringEngine().score(findings)
+    tampered = real.model_copy(update={"overall": 99})
+    assert RiskScoringEngine.verify(findings, real)
+    assert not RiskScoringEngine.verify(findings, tampered)
+
+
+@pytest.mark.parametrize(
+    ("path", "min_score", "max_score", "min_raw", "max_raw"),
+    [
+        ("examples/safe-mcp-server/server.py", 95, 100, 0, 5),
+        ("examples/medium-risk-mcp-server/server.py", 55, 85, 15, 35),
+        ("examples/vulnerable-mcp-server/server.py", 1, 20, 100, 200),
+    ],
+)
+def test_real_server_scores_in_expected_bands(
+    path: str,
+    min_score: int,
+    max_score: int,
+    min_raw: int,
+    max_raw: int,
+) -> None:
+    """Scores must be computed from real analyzer output, not hardcoded."""
+    report = Scanner(ScanConfig(target=Path(path))).run()
+    assert RiskScoringEngine.verify(report.findings, report.score)
+    assert min_score <= report.score.overall <= max_score
+    assert min_raw <= report.score.raw_risk <= max_raw
+    assert report.score.raw_risk == (
+        report.score.basis.critical * RISK_WEIGHTS[Severity.CRITICAL]
+        + report.score.basis.high * RISK_WEIGHTS[Severity.HIGH]
+        + report.score.basis.medium * RISK_WEIGHTS[Severity.MEDIUM]
+        + report.score.basis.low * RISK_WEIGHTS[Severity.LOW]
+    )
+    assert report.score.overall == security_score_from_raw_risk(report.score.raw_risk)
+
+
+def test_json_roundtrip_preserves_verifiable_score(tmp_path: Path) -> None:
+    report = Scanner(ScanConfig(target=Path("examples/vulnerable-mcp-server/server.py"))).run()
+    path = tmp_path / "report.json"
+    path.write_text(report.model_dump_json())
+    loaded = ScanReport.model_validate_json(path.read_text())
+    assert RiskScoringEngine.verify(loaded.findings, loaded.score)
+
+
+def test_safe_beats_vulnerable() -> None:
+    safe = Scanner(ScanConfig(target=Path("examples/safe-mcp-server/server.py"))).run()
+    bad = Scanner(ScanConfig(target=Path("examples/vulnerable-mcp-server/server.py"))).run()
+    assert safe.score.overall > bad.score.overall
+    assert safe.score.raw_risk < bad.score.raw_risk

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,93 @@
+"""Tests for terminal UI helpers."""
+
+from mcpaudit.reporting.models import Finding, Severity
+from mcpaudit.ui.dashboard import compute_owasp_counts, sort_findings
+from mcpaudit.ui.theme import ThemeName, get_theme
+
+
+def test_get_theme_cyber() -> None:
+    theme = get_theme("cyber")
+    assert theme.name == ThemeName.CYBER
+    assert theme.palette.cyan == "#00bfff"
+
+
+def test_get_theme_invalid() -> None:
+    try:
+        get_theme("neon")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "neon" in str(exc)
+
+
+def test_score_rating_critical() -> None:
+    theme = get_theme("cyber")
+    label, color = theme.score_rating(5)
+    assert label == "CRITICAL"
+    assert color == theme.palette.red
+
+
+def test_risk_index_color() -> None:
+    theme = get_theme("cyber")
+    assert theme.risk_index_color(90) == theme.palette.red
+    assert theme.risk_index_color(10) == theme.palette.green
+
+
+def test_score_rating_low_risk() -> None:
+    theme = get_theme("cyber")
+    label, _ = theme.score_rating(95)
+    assert label == "LOW"
+
+
+def test_sort_findings_by_severity() -> None:
+    findings = [
+        Finding(
+            id="1",
+            analyzer="tool_abuse",
+            title="Low issue",
+            description="d",
+            severity=Severity.LOW,
+            recommendation="r",
+        ),
+        Finding(
+            id="2",
+            analyzer="permission_analyzer",
+            title="Critical issue",
+            description="d",
+            severity=Severity.CRITICAL,
+            recommendation="r",
+        ),
+    ]
+    sorted_findings = sort_findings(findings)
+    assert sorted_findings[0].severity == Severity.CRITICAL
+
+
+def test_compute_owasp_counts() -> None:
+    findings = [
+        Finding(
+            id="1",
+            analyzer="prompt_injection",
+            title="inj",
+            description="d",
+            severity=Severity.HIGH,
+            recommendation="r",
+        ),
+        Finding(
+            id="2",
+            analyzer="prompt_injection",
+            title="inj2",
+            description="d",
+            severity=Severity.HIGH,
+            recommendation="r",
+        ),
+        Finding(
+            id="3",
+            analyzer="data_leakage",
+            title="leak",
+            description="d",
+            severity=Severity.MEDIUM,
+            recommendation="r",
+        ),
+    ]
+    counts = compute_owasp_counts(findings)
+    llm01 = next(item for item in counts if item[0] == "LLM01")
+    assert llm01[2] == 2


### PR DESCRIPTION
## Summary

This PR adds a Rich-based cybersecurity terminal experience for `mcpaudit scan` and replaces the old capped penalty scoring model with auditable, formula-driven risk metrics.

**CLI / UX**

- New `src/mcpaudit/ui/` package: themes (`cyber`, `minimal`, `github`), ASCII logo, hacker-style `[✓]` scan animation, fixed-width dashboard layout
- Flags: `--theme`, `--no-progress`
- Scan output shows aligned metrics (`Table.grid`), side-by-side severity + top findings panels, OWASP mapping, and transparent score formula in the terminal

**Scoring**

- **Security score** (higher is better): `round(100 × e^(-raw_risk / 50))`
- **Risk index** (higher is worse): weighted severity counts, capped at 100
- **ScoreBasis** on every `RiskScore` — documents counts used; compliance meta-findings excluded from scoring
- Runtime verification: scanner raises if recomputed score does not match findings
- Example servers: `examples/safe-mcp-server/`, `examples/medium-risk-mcp-server/` for regression bands (safe ≈ 100, medium ≈ 67, vulnerable ≈ 5)

**Docs**

- Updated `README.md`, `docs/cli.md`, `docs/getting-started.md` to match current CLI output and scoring behavior

## Type of change

- [ ] Bug fix
- [x] New feature / analyzer
- [ ] Breaking change
- [x] Documentation

## Test plan

- [x] `uv run pytest`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test (if applicable)
  - [x] `uv run mcpaudit scan examples/vulnerable-mcp-server/server.py`
  - [x] `uv run mcpaudit scan examples/safe-mcp-server/server.py`
  - [x] `uv run mcpaudit scan examples/medium-risk-mcp-server/server.py`
  - [x] `uv run mcpaudit scan examples/vulnerable-mcp-server/server.py --theme minimal --no-progress`
  - [x] `uv run mcpaudit scan examples/vulnerable-mcp-server/server.py -o report.json`

## Checklist

- [ ] CHANGELOG.md updated (if user-facing)
- [x] Tests added or updated
- [x] No secrets or credentials in code
