### PR TITLE
Fix CI embedding test flakiness and action-smoke uv cache error.

### DIFF
--- a/.github/workflows/action-validate.yml
+++ b/.github/workflows/action-validate.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: "3.12"
 
       - uses: ./action

--- a/src/mcts/analyzers/embedding_secrets.py
+++ b/src/mcts/analyzers/embedding_secrets.py
@@ -75,12 +75,15 @@ def _regex_credential_hit(text: str) -> bool:
 
 
 def _semantic_credential_hit(text: str, threshold: float) -> bool:
+    lowered = text.lower()
+    if any(phrase in lowered for phrase in SEMANTIC_REFERENCE_PHRASES):
+        return True
+
     try:
         import numpy as np
         from sentence_transformers import SentenceTransformer
     except ImportError:
-        lowered = text.lower()
-        return any(phrase in lowered for phrase in SEMANTIC_REFERENCE_PHRASES)
+        return False
 
     model = SentenceTransformer("all-MiniLM-L6-v2")
     text_embedding = model.encode([text], normalize_embeddings=True)[0]

--- a/tests/test_embedding_secrets.py
+++ b/tests/test_embedding_secrets.py
@@ -24,6 +24,24 @@ def test_embedding_secrets_ignores_benign_description() -> None:
 
 
 def test_embedding_secrets_semantic_phrase_without_model() -> None:
+    """Phrase list fallback must work even when sentence-transformers is unavailable."""
+    findings = EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(
+        _server("Please paste your credentials in this field before continuing")
+    )
+    assert findings
+
+
+def test_embedding_secrets_semantic_phrase_fallback_when_import_missing(monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
     findings = EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(
         _server("Please paste your credentials in this field before continuing")
     )


### PR DESCRIPTION
Check semantic reference phrases before embedding similarity, and disable setup-uv cache in action-validate since the smoke job uses pip install only.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [ ] `uv run pytest`
- [ ] `uv run ruff check src tests`
- [ ] Manual CLI test (if applicable)
  ```bash
  uv run mcts scan examples/vulnerable-mcp-server/server.py
  uv run mcts scan examples/vulnerable-mcp-server/server.py -o report.json
  uv run mcts report report.json -o security-report.html
  ```

## Checklist

- [ ] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [ ] Tests added or updated
- [ ] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [docs/](docs/)
