### PR TITLE
[BUG] Live probe returns empty tool lists on partial MCP failures

### DIFF
--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -57,6 +57,30 @@ def _write_report(
         output.write_text(report.model_dump_json(indent=2))
 
 
+def _print_discovery_warnings(server, stderr_file: str | None) -> None:
+    if not server.discovery_warnings:
+        return
+    console.print("[yellow]Warning:[/yellow] Live MCP discovery was incomplete:")
+    for warning in server.discovery_warnings:
+        console.print(f"  [yellow]•[/yellow] {warning}")
+    if not stderr_file:
+        console.print(
+            "  [dim]Tip: pass --stderr-file PATH when probing stdio servers to capture server stderr.[/dim]"
+        )
+
+
+def _check_strict_live(report, config: ScanConfig) -> None:
+    if not config.strict_live:
+        return
+    warnings = report.server.discovery_warnings
+    if not warnings:
+        return
+    console.print("[red]Error:[/red] --strict-live: live discovery did not complete successfully.")
+    for warning in warnings:
+        console.print(f"  [red]•[/red] {warning}")
+    raise typer.Exit(code=2)
+
+
 def _check_gates(report, config: ScanConfig) -> None:
     if config.fail_on_critical and report.summary.critical > 0:
         raise typer.Exit(code=1)
@@ -262,6 +286,13 @@ def scan(
         str | None,
         typer.Option("--stderr-file", help="Capture live server stderr to file"),
     ] = None,
+    strict_live: Annotated[
+        bool,
+        typer.Option(
+            "--strict-live",
+            help="Exit 2 when live discovery is incomplete (e.g. list_tools failed after initialize)",
+        ),
+    ] = False,
     enable_yara: Annotated[
         bool,
         typer.Option("--yara", help="Enable YARA metadata analyzer"),
@@ -420,6 +451,7 @@ def scan(
         remote_headers=remote_headers,
         protocol_probe=protocol_probe,
         stderr_file=stderr_file,
+        strict_live=strict_live,
         expand_vars=expand_vars,
         snapshot_path=snapshot,
         pip_audit=pip_audit,
@@ -492,6 +524,8 @@ def scan(
         _write_report(report, output, output_format, target=str(scan_target), remote_url=url)
         renderer.render_saved_notice(str(output))
 
+    _print_discovery_warnings(report.server, stderr_file)
+    _check_strict_live(report, config_obj)
     _check_gates(report, config_obj)
 
 

--- a/src/mcts/core/config.py
+++ b/src/mcts/core/config.py
@@ -73,6 +73,7 @@ class ScanConfig(BaseModel):
     oauth_scopes: str | None = None
     protocol_probe: bool = False
     stderr_file: str | None = None
+    strict_live: bool = False
     expand_vars: str = "auto"
     # P1 — static snapshot + supply chain
     snapshot_path: Path | None = None

--- a/src/mcts/core/scanner.py
+++ b/src/mcts/core/scanner.py
@@ -141,6 +141,10 @@ class Scanner:
                 }
             )
         findings: list[Finding] = []
+        if server_info.discovery_warnings:
+            from mcts.probe.discovery_meta import discovery_meta_findings
+
+            findings.extend(discovery_meta_findings(server_info))
 
         for analyzer in self.analyzers:
             if not self._is_enabled(analyzer):

--- a/src/mcts/discovery/merge.py
+++ b/src/mcts/discovery/merge.py
@@ -31,6 +31,8 @@ def merge_server_info(static: MCPServerInfo, live: MCPServerInfo) -> MCPServerIn
         transport="stdio-merged",
         discovery_mode="merged",
         source_files=dict(static.source_files),
+        discovery_warnings=list(live.discovery_warnings),
+        initialize_succeeded=live.initialize_succeeded,
     )
 
 

--- a/src/mcts/mcp/models.py
+++ b/src/mcts/mcp/models.py
@@ -83,3 +83,5 @@ class MCPServerInfo(BaseModel):
     source_files: dict[str, str] = Field(default_factory=dict)
     runtime_events: list[dict[str, Any]] = Field(default_factory=list)
     surface_scan: SurfaceScanOptions | None = None
+    discovery_warnings: list[str] = Field(default_factory=list)
+    initialize_succeeded: bool = False

--- a/src/mcts/probe/discovery_meta.py
+++ b/src/mcts/probe/discovery_meta.py
@@ -1,0 +1,55 @@
+"""Meta-findings and CLI helpers for incomplete live MCP discovery."""
+
+from __future__ import annotations
+
+from mcts.mcp.models import MCPServerInfo
+from mcts.reporting.models import Finding, Severity
+
+
+def list_failure_warning(operation: str, exc: Exception, stderr_file: str | None) -> str:
+    """Build a human-readable warning for a failed MCP list_* call."""
+    base = f"{operation} failed: {exc}"
+    if stderr_file:
+        return f"{base} (server stderr captured in {stderr_file})"
+    return f"{base} (re-run with --stderr-file PATH to capture server stderr)"
+
+
+def discovery_meta_findings(server: MCPServerInfo) -> list[Finding]:
+    """Emit a meta-finding when live discovery returned partial server metadata."""
+    if not server.discovery_warnings:
+        return []
+
+    tools_warning = any(w.startswith("list_tools") for w in server.discovery_warnings)
+    severity = Severity.HIGH if tools_warning else Severity.MEDIUM
+    description = (
+        "Live MCP discovery completed after initialize, but one or more list_* "
+        "operations failed. Analyzers may run against incomplete tool/prompt/resource "
+        "metadata and miss security findings."
+    )
+
+    return [
+        Finding(
+            id="live-discovery-incomplete",
+            analyzer="live_discovery",
+            title="Live MCP discovery incomplete",
+            description=description,
+            severity=severity,
+            recommendation=(
+                "Investigate MCP server list_tools/list_prompts/list_resources handlers; "
+                "increase --timeout if needed. Capture server stderr with --stderr-file "
+                "for diagnostics. Use --strict-live in CI to fail the scan when discovery "
+                "is incomplete."
+            ),
+            evidence={
+                "discovery_mode": server.discovery_mode,
+                "discovery_warnings": list(server.discovery_warnings),
+                "tool_count": len(server.tools),
+                "initialize_succeeded": server.initialize_succeeded,
+            },
+            confidence=1.0,
+        )
+    ]
+
+
+def tools_list_failed(warnings: list[str]) -> bool:
+    return any(w.startswith("list_tools") for w in warnings)

--- a/src/mcts/probe/http_session.py
+++ b/src/mcts/probe/http_session.py
@@ -48,9 +48,16 @@ async def probe_remote(config: RemoteServerConfig, timeout_seconds: int = 120) -
             async with client_ctx as (read, write, *_):
                 async with ClientSession(read, write) as session:
                     init_result = await asyncio.wait_for(session.initialize(), timeout=timeout_seconds)
-                    tools = await _list_tools(session, timeout_seconds)
-                    prompts = await _list_prompts(session, timeout_seconds)
-                    resources = await _list_resources(session, timeout_seconds)
+                    discovery_warnings: list[str] = []
+                    tools, tools_warning = await _list_tools(session, timeout_seconds)
+                    if tools_warning:
+                        discovery_warnings.append(tools_warning)
+                    prompts, prompts_warning = await _list_prompts(session, timeout_seconds)
+                    if prompts_warning:
+                        discovery_warnings.append(prompts_warning)
+                    resources, resources_warning = await _list_resources(session, timeout_seconds)
+                    if resources_warning:
+                        discovery_warnings.append(resources_warning)
                     from mcts.probe.resources import enrich_resources_with_content
 
                     resources = await enrich_resources_with_content(
@@ -66,6 +73,8 @@ async def probe_remote(config: RemoteServerConfig, timeout_seconds: int = 120) -
                         instructions=instructions,
                         transport=transport_label,
                         discovery_mode="live",
+                        discovery_warnings=discovery_warnings,
+                        initialize_succeeded=True,
                     )
     except TimeoutError as exc:
         raise MCPProbeError(f"Timed out connecting to {config.url}") from exc

--- a/src/mcts/probe/session.py
+++ b/src/mcts/probe/session.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from mcts.capability.inferrer import infer_capability
 from mcts.mcp.models import MCPPrompt, MCPResource, MCPServerInfo, MCPTool
+from mcts.probe.discovery_meta import list_failure_warning
 from mcts.probe.models import LiveServerConfig
 
 logger = logging.getLogger(__name__)
@@ -60,9 +61,22 @@ async def probe_stdio(config: LiveServerConfig, timeout_seconds: int = 120) -> M
                         session.initialize(),
                         timeout=session_timeout,
                     )
-                    tools = await _list_tools(session, session_timeout)
-                    prompts = await _list_prompts(session, session_timeout)
-                    resources = await _list_resources(session, session_timeout)
+                    discovery_warnings: list[str] = []
+                    tools, tools_warning = await _list_tools(
+                        session, session_timeout, stderr_file=config.stderr_file
+                    )
+                    if tools_warning:
+                        discovery_warnings.append(tools_warning)
+                    prompts, prompts_warning = await _list_prompts(
+                        session, session_timeout, stderr_file=config.stderr_file
+                    )
+                    if prompts_warning:
+                        discovery_warnings.append(prompts_warning)
+                    resources, resources_warning = await _list_resources(
+                        session, session_timeout, stderr_file=config.stderr_file
+                    )
+                    if resources_warning:
+                        discovery_warnings.append(resources_warning)
                     from mcts.probe.resources import enrich_resources_with_content
 
                     resources = await enrich_resources_with_content(
@@ -81,6 +95,8 @@ async def probe_stdio(config: LiveServerConfig, timeout_seconds: int = 120) -> M
                         instructions=instructions,
                         transport="stdio-live",
                         discovery_mode="live",
+                        discovery_warnings=discovery_warnings,
+                        initialize_succeeded=True,
                     )
     except TimeoutError as exc:
         raise MCPProbeError(
@@ -92,35 +108,53 @@ async def probe_stdio(config: LiveServerConfig, timeout_seconds: int = 120) -> M
         raise MCPProbeError(f"Live probe failed for '{config.command}': {exc}") from exc
 
 
-async def _list_tools(session: Any, timeout: int) -> list[MCPTool]:
+async def _list_tools(
+    session: Any,
+    timeout: int,
+    *,
+    stderr_file: str | None = None,
+) -> tuple[list[MCPTool], str | None]:
     try:
         result = await asyncio.wait_for(session.list_tools(), timeout=timeout)
     except Exception as exc:
-        logger.warning("list_tools failed: %s", exc)
-        return []
-    return [_tool_from_mcp(tool) for tool in result.tools]
+        warning = list_failure_warning("list_tools", exc, stderr_file)
+        logger.warning("%s", warning)
+        return [], warning
+    return [_tool_from_mcp(tool) for tool in result.tools], None
 
 
-async def _list_prompts(session: Any, timeout: int) -> list[MCPPrompt]:
+async def _list_prompts(
+    session: Any,
+    timeout: int,
+    *,
+    stderr_file: str | None = None,
+) -> tuple[list[MCPPrompt], str | None]:
     if not hasattr(session, "list_prompts"):
-        return []
+        return [], None
     try:
         result = await asyncio.wait_for(session.list_prompts(), timeout=timeout)
     except Exception as exc:
-        logger.warning("list_prompts failed: %s", exc)
-        return []
-    return [_prompt_from_mcp(prompt) for prompt in result.prompts]
+        warning = list_failure_warning("list_prompts", exc, stderr_file)
+        logger.warning("%s", warning)
+        return [], warning
+    return [_prompt_from_mcp(prompt) for prompt in result.prompts], None
 
 
-async def _list_resources(session: Any, timeout: int) -> list[MCPResource]:
+async def _list_resources(
+    session: Any,
+    timeout: int,
+    *,
+    stderr_file: str | None = None,
+) -> tuple[list[MCPResource], str | None]:
     if not hasattr(session, "list_resources"):
-        return []
+        return [], None
     try:
         result = await asyncio.wait_for(session.list_resources(), timeout=timeout)
     except Exception as exc:
-        logger.warning("list_resources failed: %s", exc)
-        return []
-    return [_resource_from_mcp(resource) for resource in result.resources]
+        warning = list_failure_warning("list_resources", exc, stderr_file)
+        logger.warning("%s", warning)
+        return [], warning
+    return [_resource_from_mcp(resource) for resource in result.resources], None
 
 
 def _extract_instructions(init_result: Any) -> str | None:

--- a/tests/test_discovery_meta.py
+++ b/tests/test_discovery_meta.py
@@ -1,0 +1,121 @@
+"""Tests for live discovery warning tracking and meta-findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcts.core.config import ScanConfig
+from mcts.core.scanner import Scanner
+from mcts.mcp.models import MCPServerInfo
+from mcts.probe.discovery_meta import (
+    discovery_meta_findings,
+    list_failure_warning,
+    tools_list_failed,
+)
+from mcts.probe.models import LiveServerConfig
+from mcts.probe.session import probe_stdio
+
+
+def test_list_failure_warning_includes_stderr_hint() -> None:
+    warning = list_failure_warning("list_tools", RuntimeError("boom"), None)
+    assert warning.startswith("list_tools failed:")
+    assert "--stderr-file" in warning
+
+
+def test_list_failure_warning_notes_captured_stderr() -> None:
+    warning = list_failure_warning("list_tools", RuntimeError("boom"), "/tmp/err.log")
+    assert "/tmp/err.log" in warning
+
+
+def test_discovery_meta_findings_emitted_for_warnings() -> None:
+    server = MCPServerInfo(
+        discovery_mode="live",
+        initialize_succeeded=True,
+        discovery_warnings=["list_tools failed: timeout"],
+    )
+    findings = discovery_meta_findings(server)
+    assert len(findings) == 1
+    assert findings[0].id == "live-discovery-incomplete"
+    assert findings[0].analyzer == "live_discovery"
+    assert findings[0].severity.value == "high"
+
+
+def test_tools_list_failed_detector() -> None:
+    assert not tools_list_failed(["list_prompts failed: x"])
+    assert tools_list_failed(["list_tools failed: x"])
+
+
+@pytest.mark.asyncio
+async def test_probe_stdio_records_list_tools_failure() -> None:
+    fake_init = SimpleNamespace(instructions=None, serverInfo=SimpleNamespace(version="1.0.0"))
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock(return_value=fake_init)
+    mock_session.list_tools = AsyncMock(side_effect=RuntimeError("tools unavailable"))
+    mock_session.list_prompts = AsyncMock(return_value=SimpleNamespace(prompts=[]))
+    mock_session.list_resources = AsyncMock(return_value=SimpleNamespace(resources=[]))
+
+    class FakeClientSession:
+        def __init__(self, read, write):
+            pass
+
+        async def __aenter__(self):
+            return mock_session
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeStdioClient:
+        def __init__(self, params):
+            self.params = params
+
+        async def __aenter__(self):
+            return (None, None)
+
+        async def __aexit__(self, *args):
+            return None
+
+    fake_stdio_module = SimpleNamespace(stdio_client=FakeStdioClient)
+    fake_mcp_module = SimpleNamespace(
+        ClientSession=FakeClientSession,
+        StdioServerParameters=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mcp.client.stdio":
+            return fake_stdio_module
+        if name == "mcp":
+            return fake_mcp_module
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch.object(builtins, "__import__", side_effect=fake_import):
+        info = await probe_stdio(
+            LiveServerConfig(command="python", args=["server.py"], stderr_file="/tmp/mcp.err")
+        )
+
+    assert info.initialize_succeeded is True
+    assert info.tools == []
+    assert len(info.discovery_warnings) == 1
+    assert info.discovery_warnings[0].startswith("list_tools failed:")
+    assert "/tmp/mcp.err" in info.discovery_warnings[0]
+
+
+def test_scanner_adds_meta_finding_for_partial_live_discovery(tmp_path: Path) -> None:
+    server = MCPServerInfo(
+        name="demo",
+        discovery_mode="live",
+        initialize_succeeded=True,
+        discovery_warnings=["list_tools failed: denied"],
+    )
+    config = ScanConfig(target=tmp_path, live=True)
+    report = Scanner(config).analyze_server(server)
+    meta = [f for f in report.findings if f.analyzer == "live_discovery"]
+    assert len(meta) == 1


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test (if applicable)
  ```bash
  uv run mcts scan examples/vulnerable-mcp-server/server.py
  uv run mcts scan examples/vulnerable-mcp-server/server.py -o report.json
  uv run mcts report report.json -o security-report.html
  ```

## Checklist

- [ ] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)
