### PR TITLE
docs: update setup uv@4 to @v7 in CI integration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### FIxed
 
 - `CrossServerAnalyzer` no longer counted in "analyzers run" when inventory is empty (was a silent no-op during `mcts scan`)
+- Docs: updated 'setup-uv' version from '@v4' to '@v7' in CI integration guide.
 
 ### Changed
 

--- a/docs/platform/ci-integration.md
+++ b/docs/platform/ci-integration.md
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --all-extras
 
       - name: Static security scan


### PR DESCRIPTION
Fixes #97

## Summary

The manual CI workflow example in `docs/platform/ci-integration.md` referenced
`astral-sh/setup-uv@v4`, but all actual repository workflows use `@v7`. Updated to match.

## Changes
- `docs/platform/ci-integration.md` — `setup-uv@v4` → `setup-uv@v7`
- `CHANGELOG.md` — added entry under `[Unreleased] > Fixed`