### PR TITLE
fix: trivial P3 fixes — .gitignore scan artifacts, ruff scripts src, e2e temp cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ issues/
 .vscode/
 *.swp
 .DS_Store
+
+# Scan artifacts
+*.sarif
+mcts-report.*
+regression-report.json
+inventory.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ markers = [
 [tool.ruff]
 target-version = "py311"
 line-length = 110
-src = ["src", "tests"]
+src = ["src", "tests", "scripts"]
 extend-exclude = ["eval/behavioral/handlers/parity"]
 
 [tool.ruff.lint]

--- a/scripts/cli_end_to_end.sh
+++ b/scripts/cli_end_to_end.sh
@@ -21,8 +21,10 @@ echo "== readiness heuristics =="
 uv run mcts readiness examples/baseline-mcp-server/server.py
 
 echo "== raw envelope output =="
-uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o /tmp/mcts-raw.json --no-progress
-python3 -c "import json; p=json.load(open('/tmp/mcts-raw.json')); assert 'scan_results' in p"
+RAW=$(mktemp /tmp/mcts-raw.XXXXXX.json)
+trap 'rm -f "$RAW"' EXIT
+uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o "$RAW" --no-progress
+python3 -c "import json, sys; p=json.load(open(sys.argv[1])); assert 'scan_results' in p" "$RAW"
 
 echo "== pytest =="
 uv run pytest tests/ -q --tb=no


### PR DESCRIPTION
Three trivial P3 fixes:

- Closes #98: Added `*.sarif`, `mcts-report.*`, `inventory.json`, `regression-report.json` to `.gitignore`
- Closes #82: Added `scripts` to `[tool.ruff] src` list in `pyproject.toml`
- Closes #83: Replaced hardcoded `/tmp/mcts-raw.json` with `mktemp` + `trap` cleanup in `cli_end_to_end.sh`