### PR TITLE
fix(scripts): idempotent branch protection ruleset (#79)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,8 @@ Pull requests to `main` require the **test** CI check to pass.
 ./scripts/enable-branch-protection.sh MCP-Audit/MCTS
 ```
 
+The script is **idempotent**: re-running it updates the existing `Protect main` ruleset instead of creating duplicates. Use `--dry-run` to preview without applying changes.
+
 **Option B — GitHub UI**
 
 1. Go to **Settings → Rules → Rulesets → New branch ruleset**

--- a/scripts/enable-branch-protection.sh
+++ b/scripts/enable-branch-protection.sh
@@ -2,18 +2,57 @@
 set -euo pipefail
 
 # Apply branch protection requiring the CI "test" job to pass.
+# Idempotent: updates an existing "Protect main" ruleset instead of creating duplicates.
 # Requires: gh CLI authenticated with admin access to the repository.
 #
 # Usage:
 #   ./scripts/enable-branch-protection.sh
 #   ./scripts/enable-branch-protection.sh MCP-Audit/MCTS
+#   ./scripts/enable-branch-protection.sh MCP-Audit/MCTS --dry-run
 
 REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
-RULESET_FILE="$(cd "$(dirname "$0")/.." && pwd)/.github/rulesets/main.json"
+DRY_RUN=false
+if [[ "${2:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+elif [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
 
-echo "Applying ruleset to ${REPO}..."
-gh api "repos/${REPO}/rulesets" \
-  --method POST \
-  --input "${RULESET_FILE}"
+RULESET_FILE="$(cd "$(dirname "$0")/.." && pwd)/.github/rulesets/main.json"
+RULESET_NAME="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['name'])" "${RULESET_FILE}")"
+
+echo "Checking existing rulesets on ${REPO}..."
+EXISTING_ID="$(
+  gh api "repos/${REPO}/rulesets" --paginate \
+    | python3 -c "
+import json, sys
+name = sys.argv[1]
+for row in json.load(sys.stdin):
+    if row.get('name') == name:
+        print(row.get('id', ''))
+        break
+" "${RULESET_NAME}"
+)"
+
+if [[ -n "${EXISTING_ID}" ]]; then
+  echo "Found existing ruleset \"${RULESET_NAME}\" (id=${EXISTING_ID}). Updating in place..."
+  if [[ "${DRY_RUN}" == true ]]; then
+    echo "[dry-run] Would PUT repos/${REPO}/rulesets/${EXISTING_ID}"
+    exit 0
+  fi
+  gh api "repos/${REPO}/rulesets/${EXISTING_ID}" \
+    --method PUT \
+    --input "${RULESET_FILE}"
+else
+  echo "No existing ruleset named \"${RULESET_NAME}\". Creating..."
+  if [[ "${DRY_RUN}" == true ]]; then
+    echo "[dry-run] Would POST repos/${REPO}/rulesets"
+    exit 0
+  fi
+  gh api "repos/${REPO}/rulesets" \
+    --method POST \
+    --input "${RULESET_FILE}"
+fi
 
 echo "Done. Verify at: https://github.com/${REPO}/settings/rules"


### PR DESCRIPTION
## Summary
- Update `enable-branch-protection.sh` to PUT an existing "Protect main" ruleset instead of always POSTing duplicates
- Add `--dry-run` for admin preview
- Document idempotent behavior in CONTRIBUTING.md

Closes #79

## Test plan
- [x] Script logic reviewed for GET-then-PUT/POST flow
- [ ] Admin runs `./scripts/enable-branch-protection.sh --dry-run` on repo
- [ ] Re-run script and confirm only one "Protect main" ruleset exists in GitHub Settings → Rules