### PR TITLE
refactor(sigma): expose public compile and loader APIs (#80)

### DIFF
--- a/scripts/compile_sigma_rules.py
+++ b/scripts/compile_sigma_rules.py
@@ -64,12 +64,9 @@ def rules_to_json(rules: list[MetadataSigmaRule]) -> str:
 
 
 def compile_rules(source: Path, *, merge_bundled: bool = True) -> list[MetadataSigmaRule]:
-    from mcts.taxonomy.sigma.loader import _dedupe_rules, _load_bundled_rules, _load_rules_from_directory
+    from mcts.taxonomy.sigma.loader import compile_metadata_rules
 
-    compiled = _load_rules_from_directory(source)
-    if merge_bundled:
-        compiled = _dedupe_rules(_load_bundled_rules() + compiled)
-    return _dedupe_rules(compiled)
+    return compile_metadata_rules(source, merge_bundled=merge_bundled)
 
 
 def main() -> int:

--- a/src/mcts/taxonomy/sigma/__init__.py
+++ b/src/mcts/taxonomy/sigma/__init__.py
@@ -1,6 +1,13 @@
 """MCTS Sigma rule loading and metadata matching."""
 
-from mcts.taxonomy.sigma.loader import load_metadata_rules
+from mcts.taxonomy.sigma.loader import (
+    MetadataSigmaRule,
+    compile_metadata_rules,
+    dedupe_rules,
+    load_bundled_rules,
+    load_metadata_rules,
+    load_rules_from_directory,
+)
 from mcts.taxonomy.sigma.matcher import (
     convert_sigma_pattern_to_regex,
     is_substantive_pattern,
@@ -8,8 +15,13 @@ from mcts.taxonomy.sigma.matcher import (
 )
 
 __all__ = [
+    "MetadataSigmaRule",
+    "compile_metadata_rules",
     "convert_sigma_pattern_to_regex",
+    "dedupe_rules",
     "is_substantive_pattern",
+    "load_bundled_rules",
     "load_metadata_rules",
+    "load_rules_from_directory",
     "match_sigma_pattern",
 ]

--- a/src/mcts/taxonomy/sigma/loader.py
+++ b/src/mcts/taxonomy/sigma/loader.py
@@ -59,9 +59,7 @@ def compile_metadata_rules(source: Path, *, merge_bundled: bool = True) -> list[
 @lru_cache(maxsize=4)
 def _load_bundled_rules_cached(extra_root_str: str | None) -> tuple[MetadataSigmaRule, ...]:
     extra = Path(extra_root_str) if extra_root_str else None
-    return tuple(
-        dedupe_rules(load_bundled_rules() + (load_rules_from_directory(extra) if extra else []))
-    )
+    return tuple(dedupe_rules(load_bundled_rules() + (load_rules_from_directory(extra) if extra else [])))
 
 
 def cached_metadata_rules(extra_root: Path | None = None) -> list[MetadataSigmaRule]:

--- a/src/mcts/taxonomy/sigma/loader.py
+++ b/src/mcts/taxonomy/sigma/loader.py
@@ -167,9 +167,3 @@ def dedupe_rules(rules: list[MetadataSigmaRule]) -> list[MetadataSigmaRule]:
         seen.add(key)
         unique.append(rule)
     return unique
-
-
-# Backward-compatible aliases for internal callers during transition.
-_load_bundled_rules = load_bundled_rules
-_load_rules_from_directory = load_rules_from_directory
-_dedupe_rules = dedupe_rules

--- a/src/mcts/taxonomy/sigma/loader.py
+++ b/src/mcts/taxonomy/sigma/loader.py
@@ -42,30 +42,40 @@ class MetadataSigmaRule:
 
 
 def load_metadata_rules(extra_root: Path | None = None) -> list[MetadataSigmaRule]:
-    rules = _load_bundled_rules()
+    rules = load_bundled_rules()
     if extra_root is not None:
-        rules.extend(_load_rules_from_directory(extra_root))
-    return _dedupe_rules(rules)
+        rules.extend(load_rules_from_directory(extra_root))
+    return dedupe_rules(rules)
+
+
+def compile_metadata_rules(source: Path, *, merge_bundled: bool = True) -> list[MetadataSigmaRule]:
+    """Compile Sigma YAML fixtures from *source* into metadata rules."""
+    compiled = load_rules_from_directory(source)
+    if merge_bundled:
+        compiled = dedupe_rules(load_bundled_rules() + compiled)
+    return dedupe_rules(compiled)
 
 
 @lru_cache(maxsize=4)
 def _load_bundled_rules_cached(extra_root_str: str | None) -> tuple[MetadataSigmaRule, ...]:
     extra = Path(extra_root_str) if extra_root_str else None
-    return tuple(_dedupe_rules(_load_bundled_rules() + (_load_rules_from_directory(extra) if extra else [])))
+    return tuple(
+        dedupe_rules(load_bundled_rules() + (load_rules_from_directory(extra) if extra else []))
+    )
 
 
 def cached_metadata_rules(extra_root: Path | None = None) -> list[MetadataSigmaRule]:
     return list(_load_bundled_rules_cached(str(extra_root) if extra_root else None))
 
 
-def _load_bundled_rules() -> list[MetadataSigmaRule]:
+def load_bundled_rules() -> list[MetadataSigmaRule]:
     if not _BUNDLED_RULES.exists():
         return []
     payload = json.loads(_BUNDLED_RULES.read_text(encoding="utf-8"))
     return [_rule_from_dict(row) for row in payload if isinstance(row, dict)]
 
 
-def _load_rules_from_directory(root: Path) -> list[MetadataSigmaRule]:
+def load_rules_from_directory(root: Path) -> list[MetadataSigmaRule]:
     if not root.exists():
         return []
 
@@ -149,7 +159,7 @@ def _rule_from_dict(row: dict[str, Any]) -> MetadataSigmaRule:
     )
 
 
-def _dedupe_rules(rules: list[MetadataSigmaRule]) -> list[MetadataSigmaRule]:
+def dedupe_rules(rules: list[MetadataSigmaRule]) -> list[MetadataSigmaRule]:
     seen: set[tuple[str, str, str]] = set()
     unique: list[MetadataSigmaRule] = []
     for rule in rules:
@@ -159,3 +169,9 @@ def _dedupe_rules(rules: list[MetadataSigmaRule]) -> list[MetadataSigmaRule]:
         seen.add(key)
         unique.append(rule)
     return unique
+
+
+# Backward-compatible aliases for internal callers during transition.
+_load_bundled_rules = load_bundled_rules
+_load_rules_from_directory = load_rules_from_directory
+_dedupe_rules = dedupe_rules

--- a/tests/test_sigma_compile.py
+++ b/tests/test_sigma_compile.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from mcts.taxonomy.sigma.loader import _load_bundled_rules
+from mcts.taxonomy.sigma.loader import load_bundled_rules
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES_SIGMA = ROOT / "tests" / "fixtures" / "sigma_fixtures"
@@ -14,8 +14,17 @@ COMPILE_SCRIPT = ROOT / "scripts" / "compile_sigma_rules.py"
 
 
 def test_bundled_sigma_rules_load() -> None:
-    rules = _load_bundled_rules()
+    rules = load_bundled_rules()
     assert len(rules) >= 20
+
+
+def test_compile_metadata_rules_public_api() -> None:
+    from mcts.taxonomy.sigma import compile_metadata_rules, load_rules_from_directory
+
+    rules = load_rules_from_directory(FIXTURES_SIGMA)
+    assert len(rules) >= 6
+    compiled = compile_metadata_rules(FIXTURES_SIGMA, merge_bundled=False)
+    assert len(compiled) == len(rules)
 
 
 def test_sigma_bundle_in_sync() -> None:


### PR DESCRIPTION
## Summary
- Promote `load_bundled_rules`, `load_rules_from_directory`, `dedupe_rules`, and `compile_metadata_rules` as public loader APIs
- Update `compile_sigma_rules.py` and tests to use the public surface instead of private underscore helpers

Closes #80

## Test plan
- [x] `uv run pytest tests/test_sigma_compile.py` — 4 passed
- [x] `scripts/compile_sigma_rules.py --check` succeeds