### PR TITLE
fix(api): add rate limits, body caps, and scan concurrency (#85)

### DIFF
--- a/src/mcts/api/app.py
+++ b/src/mcts/api/app.py
@@ -219,8 +219,7 @@ async def scan_all_prompts(req: ScanRequest) -> dict[str, Any]:
     server = await _discover_async(req)
     prompts = cap_fanout(server.prompts, label="prompts")
     reports = [
-        await _scan_server_async(req, _filter_server(server, prompt_name=prompt.name))
-        for prompt in prompts
+        await _scan_server_async(req, _filter_server(server, prompt_name=prompt.name)) for prompt in prompts
     ]
     return {
         "server_url": req.url or req.target,

--- a/src/mcts/api/app.py
+++ b/src/mcts/api/app.py
@@ -6,9 +6,15 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from mcts.api import limits
 from mcts.api.auth import require_api_key
+from mcts.api.limits import (
+    RequestLimitsMiddleware,
+    cap_fanout,
+    run_scan_with_limits,
+)
 from mcts.core.config import ScanConfig
 from mcts.core.scanner import Scanner
 from mcts.mcp.client import MCPClient
@@ -17,6 +23,7 @@ from mcts.readiness.runner import run_readiness
 from mcts.reporting.models import ScanReport
 
 app = FastAPI(title="MCTS API", version="0.1.0")
+app.add_middleware(RequestLimitsMiddleware)
 _auth = [Depends(require_api_key)]
 
 
@@ -44,6 +51,14 @@ class ScanRequest(BaseModel):
     runtime_events: list[dict[str, Any]] = Field(default_factory=list)
     fail_on_critical: bool = False
     min_score: int | None = Field(default=None, ge=0, le=100)
+
+    @field_validator("runtime_events")
+    @classmethod
+    def _limit_runtime_events(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        limit = limits.max_runtime_events()
+        if len(value) > limit:
+            raise ValueError(f"runtime_events exceeds maximum length of {limit}")
+        return value
 
 
 class ToolScanRequest(ScanRequest):
@@ -117,6 +132,14 @@ def _scan_server(req: ScanRequest, server: MCPServerInfo) -> dict[str, Any]:
     return report.model_dump()
 
 
+async def _discover_async(req: ScanRequest) -> MCPServerInfo:
+    return await run_scan_with_limits(lambda: _discover(req))
+
+
+async def _scan_server_async(req: ScanRequest, server: MCPServerInfo) -> dict[str, Any]:
+    return await run_scan_with_limits(lambda: _scan_server(req, server))
+
+
 def _filter_server(
     server: MCPServerInfo,
     *,
@@ -154,30 +177,36 @@ def _filter_server(
 
 
 @app.post("/scan", dependencies=_auth)
-def scan_all(req: ScanRequest) -> dict[str, Any]:
-    return _scan_server(req, _discover(req))
+async def scan_all(req: ScanRequest) -> dict[str, Any]:
+    server = await _discover_async(req)
+    return await _scan_server_async(req, server)
 
 
 @app.post("/scan-tool", dependencies=_auth)
-def scan_tool(req: ToolScanRequest) -> dict[str, Any]:
-    server = _filter_server(_discover(req), tool_name=req.tool_name)
-    return _scan_server(req, server)
+async def scan_tool(req: ToolScanRequest) -> dict[str, Any]:
+    server = _filter_server(await _discover_async(req), tool_name=req.tool_name)
+    return await _scan_server_async(req, server)
 
 
 @app.post("/scan-all-tools", dependencies=_auth)
-def scan_all_tools(req: ScanRequest) -> dict[str, Any]:
-    server = _discover(req)
+async def scan_all_tools(req: ScanRequest) -> dict[str, Any]:
+    server = await _discover_async(req)
+    tools = cap_fanout(server.tools, label="tools")
+    reports = []
+    for tool in tools:
+        filtered = _filter_server(server, tool_name=tool.name)
+        reports.append(await _scan_server_async(req, filtered))
     return {
         "server_url": req.url or req.target,
-        "tool_count": len(server.tools),
-        "reports": [_scan_server(req, _filter_server(server, tool_name=tool.name)) for tool in server.tools],
+        "tool_count": len(tools),
+        "reports": reports,
     }
 
 
 @app.post("/scan-prompt", dependencies=_auth)
-def scan_prompt(req: PromptScanRequest) -> dict[str, Any]:
-    server = _filter_server(_discover(req), prompt_name=req.prompt_name)
-    payload = _scan_server(req, server)
+async def scan_prompt(req: PromptScanRequest) -> dict[str, Any]:
+    server = _filter_server(await _discover_async(req), prompt_name=req.prompt_name)
+    payload = await _scan_server_async(req, server)
     return {
         "server_url": req.url or req.target,
         "prompt_name": req.prompt_name,
@@ -186,21 +215,24 @@ def scan_prompt(req: PromptScanRequest) -> dict[str, Any]:
 
 
 @app.post("/scan-all-prompts", dependencies=_auth)
-def scan_all_prompts(req: ScanRequest) -> dict[str, Any]:
-    server = _discover(req)
+async def scan_all_prompts(req: ScanRequest) -> dict[str, Any]:
+    server = await _discover_async(req)
+    prompts = cap_fanout(server.prompts, label="prompts")
+    reports = [
+        await _scan_server_async(req, _filter_server(server, prompt_name=prompt.name))
+        for prompt in prompts
+    ]
     return {
         "server_url": req.url or req.target,
-        "total_prompts": len(server.prompts),
-        "reports": [
-            _scan_server(req, _filter_server(server, prompt_name=prompt.name)) for prompt in server.prompts
-        ],
+        "total_prompts": len(prompts),
+        "reports": reports,
     }
 
 
 @app.post("/scan-resource", dependencies=_auth)
-def scan_resource(req: ResourceScanRequest) -> dict[str, Any]:
-    server = _filter_server(_discover(req), resource_uri=req.resource_uri)
-    payload = _scan_server(req, server)
+async def scan_resource(req: ResourceScanRequest) -> dict[str, Any]:
+    server = _filter_server(await _discover_async(req), resource_uri=req.resource_uri)
+    payload = await _scan_server_async(req, server)
     return {
         "server_url": req.url or req.target,
         "resource_uri": req.resource_uri,
@@ -209,22 +241,24 @@ def scan_resource(req: ResourceScanRequest) -> dict[str, Any]:
 
 
 @app.post("/scan-all-resources", dependencies=_auth)
-def scan_all_resources(req: ScanRequest) -> dict[str, Any]:
-    server = _discover(req)
+async def scan_all_resources(req: ScanRequest) -> dict[str, Any]:
+    server = await _discover_async(req)
+    resources = cap_fanout(server.resources, label="resources")
+    reports = [
+        await _scan_server_async(req, _filter_server(server, resource_uri=resource.uri))
+        for resource in resources
+    ]
     return {
         "server_url": req.url or req.target,
-        "total_resources": len(server.resources),
-        "reports": [
-            _scan_server(req, _filter_server(server, resource_uri=resource.uri))
-            for resource in server.resources
-        ],
+        "total_resources": len(resources),
+        "reports": reports,
     }
 
 
 @app.post("/scan-instructions", dependencies=_auth)
-def scan_instructions(req: ScanRequest) -> dict[str, Any]:
-    server = _filter_server(_discover(req), instructions_only=True)
-    payload = _scan_server(req, server)
+async def scan_instructions(req: ScanRequest) -> dict[str, Any]:
+    server = _filter_server(await _discover_async(req), instructions_only=True)
+    payload = await _scan_server_async(req, server)
     return {
         "server_url": req.url or req.target,
         "instructions": server.instructions,
@@ -233,7 +267,7 @@ def scan_instructions(req: ScanRequest) -> dict[str, Any]:
 
 
 @app.post("/readiness", dependencies=_auth)
-def readiness(req: ReadinessRequest) -> dict[str, Any]:
+async def readiness(req: ReadinessRequest) -> dict[str, Any]:
     config = ScanConfig(
         target=Path(req.target),
         live=req.live or bool(req.url),
@@ -241,17 +275,21 @@ def readiness(req: ReadinessRequest) -> dict[str, Any]:
         live_consent=req.live or bool(req.url),
         readiness_opa=req.enable_opa,
     )
-    try:
-        report = run_readiness(config)
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return {
-        "target": report.target,
-        "tools_checked": report.tools_checked,
-        "readiness_score": report.readiness_score,
-        "production_ready": report.production_ready,
-        "findings": [finding.model_dump() for finding in report.findings],
-    }
+
+    def _run() -> dict[str, Any]:
+        try:
+            report = run_readiness(config)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {
+            "target": report.target,
+            "tools_checked": report.tools_checked,
+            "readiness_score": report.readiness_score,
+            "production_ready": report.production_ready,
+            "findings": [finding.model_dump() for finding in report.findings],
+        }
+
+    return await run_scan_with_limits(_run)
 
 
 def create_app() -> FastAPI:

--- a/src/mcts/api/limits.py
+++ b/src/mcts/api/limits.py
@@ -124,7 +124,9 @@ def validate_scan_request_payload(payload: dict[str, Any]) -> None:
 class RequestLimitsMiddleware(BaseHTTPMiddleware):
     """Enforce body size and per-client rate limits."""
 
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         if request.method in {"POST", "PUT", "PATCH"}:
             content_length = request.headers.get("content-length")
             if content_length:

--- a/src/mcts/api/limits.py
+++ b/src/mcts/api/limits.py
@@ -21,8 +21,13 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 30
 DEFAULT_MAX_LIST_ITEMS = 100
 DEFAULT_MAX_RUNTIME_EVENTS = 500
 
-_scan_semaphore: asyncio.Semaphore | None = None
-_scan_semaphore_limit = 0
+
+class _ScanConcurrencyState:
+    semaphore: asyncio.Semaphore | None = None
+    limit: int = 0
+
+
+_scan_concurrency = _ScanConcurrencyState()
 _rate_lock = threading.Lock()
 _rate_buckets: dict[str, list[float]] = defaultdict(list)
 
@@ -62,11 +67,10 @@ def max_runtime_events() -> int:
 
 
 def _scan_semaphore_for(limit: int) -> asyncio.Semaphore:
-    global _scan_semaphore, _scan_semaphore_limit
-    if _scan_semaphore is None or _scan_semaphore_limit != limit:
-        _scan_semaphore = asyncio.Semaphore(limit)
-        _scan_semaphore_limit = limit
-    return _scan_semaphore
+    if _scan_concurrency.semaphore is None or _scan_concurrency.limit != limit:
+        _scan_concurrency.semaphore = asyncio.Semaphore(limit)
+        _scan_concurrency.limit = limit
+    return _scan_concurrency.semaphore
 
 
 def _client_key(request: Request) -> str:

--- a/src/mcts/api/limits.py
+++ b/src/mcts/api/limits.py
@@ -1,0 +1,166 @@
+"""Request limits, rate limiting, and scan concurrency controls for the REST API."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+DEFAULT_MAX_BODY_BYTES = 1_048_576  # 1 MiB
+DEFAULT_MAX_CONCURRENT_SCANS = 2
+DEFAULT_MAX_FANOUT_ITEMS = 50
+DEFAULT_RATE_LIMIT_PER_MINUTE = 30
+DEFAULT_MAX_LIST_ITEMS = 100
+DEFAULT_MAX_RUNTIME_EVENTS = 500
+
+_scan_semaphore: asyncio.Semaphore | None = None
+_scan_semaphore_limit = 0
+_rate_lock = threading.Lock()
+_rate_buckets: dict[str, list[float]] = defaultdict(list)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def max_body_bytes() -> int:
+    return _env_int("MCTS_API_MAX_BODY_BYTES", DEFAULT_MAX_BODY_BYTES)
+
+
+def max_concurrent_scans() -> int:
+    return _env_int("MCTS_API_MAX_CONCURRENT_SCANS", DEFAULT_MAX_CONCURRENT_SCANS)
+
+
+def max_fanout_items() -> int:
+    return _env_int("MCTS_API_MAX_FANOUT_ITEMS", DEFAULT_MAX_FANOUT_ITEMS)
+
+
+def rate_limit_per_minute() -> int:
+    return _env_int("MCTS_API_RATE_LIMIT_PER_MINUTE", DEFAULT_RATE_LIMIT_PER_MINUTE)
+
+
+def max_list_items() -> int:
+    return _env_int("MCTS_API_MAX_LIST_ITEMS", DEFAULT_MAX_LIST_ITEMS)
+
+
+def max_runtime_events() -> int:
+    return _env_int("MCTS_API_MAX_RUNTIME_EVENTS", DEFAULT_MAX_RUNTIME_EVENTS)
+
+
+def _scan_semaphore_for(limit: int) -> asyncio.Semaphore:
+    global _scan_semaphore, _scan_semaphore_limit
+    if _scan_semaphore is None or _scan_semaphore_limit != limit:
+        _scan_semaphore = asyncio.Semaphore(limit)
+        _scan_semaphore_limit = limit
+    return _scan_semaphore
+
+
+def _client_key(request: Request) -> str:
+    api_key = request.headers.get("X-API-Key", "").strip()
+    if api_key:
+        return f"key:{api_key}"
+    client = request.client
+    host = client.host if client else "unknown"
+    return f"ip:{host}"
+
+
+def reset_rate_limits_for_tests() -> None:
+    """Clear in-memory rate limit buckets (test helper)."""
+    with _rate_lock:
+        _rate_buckets.clear()
+
+
+def _check_rate_limit(key: str) -> Response | None:
+    limit = rate_limit_per_minute()
+    now = time.monotonic()
+    window_start = now - 60.0
+    with _rate_lock:
+        bucket = _rate_buckets[key]
+        _rate_buckets[key] = [stamp for stamp in bucket if stamp >= window_start]
+        if len(_rate_buckets[key]) >= limit:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded; retry later"},
+            )
+        _rate_buckets[key].append(now)
+    return None
+
+
+def validate_scan_request_payload(payload: dict[str, Any]) -> None:
+    """Reject oversized list fields before scan work starts."""
+    list_limits = {
+        "runtime_events": max_runtime_events(),
+        "tool_filter": max_list_items(),
+        "analyzer_filter": max_list_items(),
+        "severity_filter": max_list_items(),
+        "analyzers": max_list_items(),
+        "technique_filter": max_list_items(),
+        "surfaces": max_list_items(),
+        "resource_mime_allowlist": max_list_items(),
+    }
+    for field, limit in list_limits.items():
+        value = payload.get(field)
+        if isinstance(value, list) and len(value) > limit:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Field '{field}' exceeds maximum length of {limit}",
+            )
+
+
+class RequestLimitsMiddleware(BaseHTTPMiddleware):
+    """Enforce body size and per-client rate limits."""
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        if request.method in {"POST", "PUT", "PATCH"}:
+            content_length = request.headers.get("content-length")
+            if content_length:
+                try:
+                    size = int(content_length)
+                except ValueError:
+                    size = 0
+                if size > max_body_bytes():
+                    return JSONResponse(
+                        status_code=413,
+                        content={"detail": f"Request body exceeds {max_body_bytes()} bytes"},
+                    )
+
+            blocked = _check_rate_limit(_client_key(request))
+            if blocked is not None:
+                return blocked
+
+        return await call_next(request)
+
+
+async def run_scan_with_limits(func: Callable[[], Any]) -> Any:
+    """Acquire scan semaphore and run blocking scan work off the event loop."""
+    semaphore = _scan_semaphore_for(max_concurrent_scans())
+    if semaphore.locked() and semaphore._value <= 0:  # noqa: SLF001
+        raise HTTPException(status_code=503, detail="Scan queue full; retry later")
+
+    async with semaphore:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func)
+
+
+def cap_fanout(items: list[Any], *, label: str) -> list[Any]:
+    limit = max_fanout_items()
+    if len(items) > limit:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Too many {label} ({len(items)}); maximum fan-out is {limit}",
+        )
+    return items

--- a/tests/test_api_limits.py
+++ b/tests/test_api_limits.py
@@ -1,0 +1,54 @@
+"""Tests for API rate limits, body caps, and scan concurrency."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_api_rejects_oversized_content_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from mcts.api import limits
+    from mcts.api.app import app
+
+    monkeypatch.setattr(limits, "max_body_bytes", lambda: 128)
+    client = TestClient(app)
+    response = client.post(
+        "/scan",
+        json={"target": "."},
+        headers={"Content-Length": "9999"},
+    )
+    assert response.status_code == 413
+
+
+def test_api_rejects_oversized_runtime_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from mcts.api import limits
+    from mcts.api.app import app
+
+    monkeypatch.setattr(limits, "max_runtime_events", lambda: 2)
+    client = TestClient(app)
+    response = client.post(
+        "/scan",
+        json={"target": ".", "runtime_events": [{}, {}, {}]},
+    )
+    assert response.status_code == 422
+
+
+def test_api_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from mcts.api import limits
+    from mcts.api.app import app
+
+    limits.reset_rate_limits_for_tests()
+    monkeypatch.setattr(limits, "rate_limit_per_minute", lambda: 1)
+    client = TestClient(app)
+    first = client.post("/readiness", json={"target": "."})
+    second = client.post("/readiness", json={"target": "."})
+    assert first.status_code == 200
+    assert second.status_code == 429


### PR DESCRIPTION
## Summary
- Add `RequestLimitsMiddleware` for max body size and per-client rate limiting
- Cap fan-out on `/scan-all-tools`, `/scan-all-prompts`, and `/scan-all-resources`
- Validate oversized list fields (including `runtime_events`) in request models
- Run blocking scan work through a bounded semaphore via `run_in_executor`

Closes #85

## Test plan
- [x] `uv run pytest tests/test_api_limits.py tests/test_readiness_and_api.py` — 10 passed
- [ ] Verify `413` on oversized `Content-Length`
- [ ] Verify `429` when rate limit exceeded
- [ ] Verify `503` when scan queue is saturated under load