### PR TITLE
feat(discovery): add Go and Rust static MCP discovery (#67)

### DIFF
--- a/examples/bench/go-mcp-server/main.go
+++ b/examples/bench/go-mcp-server/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Example Go MCP server for MCTS static discovery benchmarks.
+func main() {}
+
+func registerTools(server interface{}) {
+	_ = server
+}
+
+func runShellCommand(cmd string) error {
+	return exec.Command(cmd).Run()
+}
+
+func handleDeletePath(path string) error {
+	switch path {
+	case "noop":
+		return nil
+	default:
+		return nil
+	}
+}
+
+var _ = context.Background

--- a/examples/bench/go-mcp-server/server.go
+++ b/examples/bench/go-mcp-server/server.go
@@ -1,0 +1,16 @@
+// Example Go MCP registration patterns for static discovery tests.
+package main
+
+import "os/exec"
+
+func setup(server *MockServer) {
+	server.AddTool("run_shell", "Execute a shell command from user input", func(cmd string) error {
+		return exec.Command(cmd).Run()
+	})
+	server.RegisterTool("list_files", "Read-only directory listing")
+}
+
+type MockServer struct{}
+
+func (s *MockServer) AddTool(name string, description string, handler interface{}) {}
+func (s *MockServer) RegisterTool(name string, description string) {}

--- a/examples/bench/rust-mcp-server/src/main.rs
+++ b/examples/bench/rust-mcp-server/src/main.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+// Example Rust MCP server for MCTS static discovery benchmarks.
+
+pub fn register_tools(server: &mut MockServer) {
+    server.tool("run_command", "Spawn a process from user input");
+}
+
+pub fn run_tool(cmd: &str) -> std::io::Result<()> {
+    Command::new(cmd).spawn()?.wait()?;
+    Ok(())
+}
+
+pub struct MockServer;
+
+impl MockServer {
+    pub fn tool(&mut self, name: &str, description: &str) {}
+}
+
+pub fn call_tool(name: &str) {
+    match name {
+        "run_command" => {}
+        "list_files" => {}
+        _ => {}
+    }
+}

--- a/src/mcts/discovery/static_go.py
+++ b/src/mcts/discovery/static_go.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any
 
 from mcts.capability.inferrer import infer_capability
 from mcts.core.config import ScanConfig

--- a/src/mcts/discovery/static_go.py
+++ b/src/mcts/discovery/static_go.py
@@ -1,0 +1,216 @@
+"""Repository-wide static MCP tool discovery for Go."""
+
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+from mcts.capability.inferrer import infer_capability
+from mcts.core.config import ScanConfig
+from mcts.core.target import ScanTarget, TargetKind
+from mcts.mcp.models import MCPServerInfo, MCPTool
+
+GO_EXTENSIONS = frozenset({".go"})
+GO_GLOBS = ("**/*.go",)
+
+MCP_FILE_INDICATORS = (
+    "AddTool(",
+    "RegisterTool(",
+    "ListToolsRequestSchema",
+    "CallToolRequestSchema",
+    "github.com/modelcontextprotocol/go-sdk",
+    "github.com/mark3labs/mcp-go",
+    "mcp.NewServer",
+    "server.AddTool",
+)
+
+DEFAULT_SKIP_PATH_PARTS = frozenset({"tests", "test", "vendor", "testdata"})
+
+ADD_TOOL_PATTERN = re.compile(
+    r"\.AddTool\s*\(\s*(?:mcp\.)?Tool\s*\{[^}]*Name\s*:\s*\"([^\"]+)\"",
+    re.MULTILINE | re.DOTALL,
+)
+ADD_TOOL_STRING_PATTERN = re.compile(
+    r"\.AddTool\s*\(\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+REGISTER_TOOL_PATTERN = re.compile(
+    r"RegisterTool\s*\(\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+DESCRIPTION_PATTERN = re.compile(
+    r"Description\s*:\s*\"([^\"]+)\"",
+)
+CALL_TOOL_NAME_PATTERN = re.compile(
+    r"case\s+[\"']([^\"']+)[\"']\s*:",
+)
+
+
+class GoStaticDiscovery:
+    """Discover MCP tools by walking Go source files."""
+
+    def __init__(self, config: ScanConfig) -> None:
+        self.config = config
+        self.target = ScanTarget(config.target)
+
+    def discover(self) -> MCPServerInfo:
+        if self.target.kind == TargetKind.FILE:
+            return self._discover_file(self.target.path)
+
+        source_files = self._collect_source_files(self.target.path)
+        tools: list[MCPTool] = []
+        for file_path in source_files:
+            tools.extend(self._parse_tools_from_file(Path(file_path)))
+
+        return MCPServerInfo(
+            name=self.target.path.name,
+            tools=_dedupe_tools(tools),
+            transport="stdio",
+            discovery_mode="static",
+            source_files=source_files,
+        )
+
+    def _discover_file(self, file_path: Path) -> MCPServerInfo:
+        if not file_path.exists():
+            return MCPServerInfo(name=str(file_path), tools=[])
+
+        content = self._read_file(file_path)
+        tools = _dedupe_tools(self._parse_tools_from_content(file_path, content))
+        return MCPServerInfo(
+            name=file_path.stem,
+            tools=tools,
+            transport="stdio",
+            discovery_mode="static",
+            source_files={str(file_path): content},
+        )
+
+    def _collect_source_files(self, root: Path) -> dict[str, str]:
+        files: dict[str, str] = {}
+        for glob in GO_GLOBS:
+            for path in sorted(root.glob(glob)):
+                if not self._should_scan(path, root):
+                    continue
+                content = self._read_file(path)
+                if content and self._looks_like_mcp_file(content):
+                    files[str(path)] = content
+        return files
+
+    def _should_scan(self, path: Path, root: Path) -> bool:
+        if path.suffix.lower() not in GO_EXTENSIONS:
+            return False
+        rel = path.relative_to(root)
+        if set(rel.parts) & DEFAULT_SKIP_PATH_PARTS:
+            return False
+        if any(part in self.config.exclude_dirs for part in rel.parts):
+            return False
+        rel_str = str(rel)
+        if self.config.exclude_globs and any(fnmatch(rel_str, g) for g in self.config.exclude_globs):
+            return False
+        if self.config.include_globs:
+            py_or_js_only = all(
+                g.endswith(".py") or g.endswith(".ts") or g.endswith(".js") for g in self.config.include_globs
+            )
+            if py_or_js_only:
+                return True
+            if not any(fnmatch(rel_str, g) for g in self.config.include_globs):
+                return False
+        try:
+            if path.stat().st_size > self.config.max_file_bytes:
+                return False
+        except OSError:
+            return False
+        return True
+
+    def _read_file(self, path: Path) -> str:
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return ""
+
+    def _looks_like_mcp_file(self, content: str) -> bool:
+        return any(indicator in content for indicator in MCP_FILE_INDICATORS)
+
+    def _parse_tools_from_file(self, file_path: Path) -> list[MCPTool]:
+        content = self._read_file(file_path)
+        if not content:
+            return []
+        return self._parse_tools_from_content(file_path, content)
+
+    def _parse_tools_from_content(self, file_path: Path, content: str) -> list[MCPTool]:
+        tools: list[MCPTool] = []
+        for pattern in (ADD_TOOL_STRING_PATTERN, REGISTER_TOOL_PATTERN):
+            for match in pattern.finditer(content):
+                tools.append(self._tool_from_match(file_path, content, match))
+        for match in ADD_TOOL_PATTERN.finditer(content):
+            tools.append(self._tool_from_struct_match(file_path, content, match))
+        tools.extend(self._tools_from_call_handler(file_path, content, tools))
+        return tools
+
+    def _tool_from_match(self, file_path: Path, content: str, match: re.Match[str]) -> MCPTool:
+        tool_name = match.group(1)
+        line = content[: match.start()].count("\n") + 1
+        window = content[match.start() : match.start() + 1200]
+        description = _first_match(DESCRIPTION_PATTERN, window) or ""
+        tool = MCPTool(
+            name=tool_name,
+            description=description,
+            input_schema={"type": "object", "properties": {}},
+            source_file=str(file_path),
+            source_line=line,
+            handler_snippet=_handler_snippet(content, match.start()),
+        )
+        tool.capability = infer_capability(tool)
+        return tool
+
+    def _tool_from_struct_match(self, file_path: Path, content: str, match: re.Match[str]) -> MCPTool:
+        return self._tool_from_match(file_path, content, match)
+
+    def _tools_from_call_handler(
+        self, file_path: Path, content: str, existing: list[MCPTool]
+    ) -> list[MCPTool]:
+        known = {tool.name for tool in existing}
+        tools: list[MCPTool] = []
+        for match in CALL_TOOL_NAME_PATTERN.finditer(content):
+            tool_name = match.group(1)
+            if tool_name in known:
+                continue
+            line = content[: match.start()].count("\n") + 1
+            tool = MCPTool(
+                name=tool_name,
+                source_file=str(file_path),
+                source_line=line,
+                handler_snippet=_handler_snippet(content, match.start(), max_lines=30),
+            )
+            tool.capability = infer_capability(tool)
+            tools.append(tool)
+            known.add(tool_name)
+        return tools
+
+
+def _dedupe_tools(tools: list[MCPTool]) -> list[MCPTool]:
+    by_name: dict[str, MCPTool] = {}
+    for tool in tools:
+        existing = by_name.get(tool.name)
+        if existing is None or _tool_richness(tool) > _tool_richness(existing):
+            by_name[tool.name] = tool
+    return list(by_name.values())
+
+
+def _tool_richness(tool: MCPTool) -> int:
+    score = len(tool.input_schema.get("properties", {}))
+    score += 2 if tool.description else 0
+    score += 2 if tool.handler_snippet else 0
+    return score
+
+
+def _first_match(pattern: re.Pattern[str], text: str) -> str | None:
+    match = pattern.search(text)
+    return match.group(1) if match else None
+
+
+def _handler_snippet(content: str, start: int, max_lines: int = 40) -> str:
+    line_start = content.rfind("\n", 0, start) + 1
+    lines = content[line_start:].splitlines()[:max_lines]
+    return "\n".join(lines)

--- a/src/mcts/discovery/static_runner.py
+++ b/src/mcts/discovery/static_runner.py
@@ -6,8 +6,10 @@ from mcts.core.config import ScanConfig
 from mcts.core.target import ScanTarget, TargetKind
 from mcts.discovery.instruction_files import MARKDOWN_SUFFIXES, discover_instruction_surfaces
 from mcts.discovery.static import StaticDiscovery
+from mcts.discovery.static_go import GO_EXTENSIONS, GoStaticDiscovery
 from mcts.discovery.static_js import JS_EXTENSIONS, JsStaticDiscovery
 from mcts.discovery.static_merge import merge_static_server_info
+from mcts.discovery.static_rust import RUST_EXTENSIONS, RustStaticDiscovery
 from mcts.mcp.models import MCPServerInfo
 
 
@@ -30,6 +32,16 @@ def discover_static(config: ScanConfig) -> MCPServerInfo:
                 JsStaticDiscovery(config).discover(),
                 discover_instruction_surfaces(config),
             )
+        if suffix in GO_EXTENSIONS and _go_enabled(langs):
+            return merge_static_server_info(
+                GoStaticDiscovery(config).discover(),
+                discover_instruction_surfaces(config),
+            )
+        if suffix in RUST_EXTENSIONS and _rust_enabled(langs):
+            return merge_static_server_info(
+                RustStaticDiscovery(config).discover(),
+                discover_instruction_surfaces(config),
+            )
         empty = MCPServerInfo(name=target.path.stem, discovery_mode="empty")
         return merge_static_server_info(empty, discover_instruction_surfaces(config))
 
@@ -38,6 +50,10 @@ def discover_static(config: ScanConfig) -> MCPServerInfo:
         results.append(StaticDiscovery(config).discover())
     if _js_enabled(langs):
         results.append(JsStaticDiscovery(config).discover())
+    if _go_enabled(langs):
+        results.append(GoStaticDiscovery(config).discover())
+    if _rust_enabled(langs):
+        results.append(RustStaticDiscovery(config).discover())
     results.append(discover_instruction_surfaces(config))
 
     if not results:
@@ -51,3 +67,11 @@ def _python_enabled(langs: set[str]) -> bool:
 
 def _js_enabled(langs: set[str]) -> bool:
     return "typescript" in langs or "javascript" in langs or "js" in langs
+
+
+def _go_enabled(langs: set[str]) -> bool:
+    return "go" in langs or "golang" in langs
+
+
+def _rust_enabled(langs: set[str]) -> bool:
+    return "rust" in langs or "rs" in langs

--- a/src/mcts/discovery/static_rust.py
+++ b/src/mcts/discovery/static_rust.py
@@ -153,9 +153,7 @@ class RustStaticDiscovery:
         tools.extend(self._tools_from_match_arms(file_path, content, tools))
         return tools
 
-    def _tools_from_match_arms(
-        self, file_path: Path, content: str, existing: list[MCPTool]
-    ) -> list[MCPTool]:
+    def _tools_from_match_arms(self, file_path: Path, content: str, existing: list[MCPTool]) -> list[MCPTool]:
         if "CallToolRequest" not in content and "call_tool" not in content:
             return []
         known = {tool.name for tool in existing}

--- a/src/mcts/discovery/static_rust.py
+++ b/src/mcts/discovery/static_rust.py
@@ -1,0 +1,204 @@
+"""Repository-wide static MCP tool discovery for Rust."""
+
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+
+from mcts.capability.inferrer import infer_capability
+from mcts.core.config import ScanConfig
+from mcts.core.target import ScanTarget, TargetKind
+from mcts.mcp.models import MCPServerInfo, MCPTool
+
+RUST_EXTENSIONS = frozenset({".rs"})
+RUST_GLOBS = ("**/*.rs",)
+
+MCP_FILE_INDICATORS = (
+    "rmcp::",
+    "mcp_server::",
+    "Tool::new",
+    "Server::tool",
+    ".tool(",
+    "ListToolsRequest",
+    "CallToolRequest",
+    "call_tool",
+    "modelcontextprotocol",
+)
+
+DEFAULT_SKIP_PATH_PARTS = frozenset({"tests", "test", "target", "benches"})
+
+TOOL_NEW_PATTERN = re.compile(
+    r"Tool::new\s*\(\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+TOOL_MACRO_PATTERN = re.compile(
+    r"\.tool\s*\(\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+DESCRIPTION_PATTERN = re.compile(
+    r"description\s*:\s*[\"']([^\"']+)[\"']",
+)
+MATCH_ARM_PATTERN = re.compile(
+    r"[\"']([^\"']+)[\"']\s*=>\s*\{",
+)
+
+
+class RustStaticDiscovery:
+    """Discover MCP tools by walking Rust source files."""
+
+    def __init__(self, config: ScanConfig) -> None:
+        self.config = config
+        self.target = ScanTarget(config.target)
+
+    def discover(self) -> MCPServerInfo:
+        if self.target.kind == TargetKind.FILE:
+            return self._discover_file(self.target.path)
+
+        source_files = self._collect_source_files(self.target.path)
+        tools: list[MCPTool] = []
+        for file_path in source_files:
+            tools.extend(self._parse_tools_from_file(Path(file_path)))
+
+        return MCPServerInfo(
+            name=self.target.path.name,
+            tools=_dedupe_tools(tools),
+            transport="stdio",
+            discovery_mode="static",
+            source_files=source_files,
+        )
+
+    def _discover_file(self, file_path: Path) -> MCPServerInfo:
+        if not file_path.exists():
+            return MCPServerInfo(name=str(file_path), tools=[])
+
+        content = self._read_file(file_path)
+        tools = _dedupe_tools(self._parse_tools_from_content(file_path, content))
+        return MCPServerInfo(
+            name=file_path.stem,
+            tools=tools,
+            transport="stdio",
+            discovery_mode="static",
+            source_files={str(file_path): content},
+        )
+
+    def _collect_source_files(self, root: Path) -> dict[str, str]:
+        files: dict[str, str] = {}
+        for glob in RUST_GLOBS:
+            for path in sorted(root.glob(glob)):
+                if not self._should_scan(path, root):
+                    continue
+                content = self._read_file(path)
+                if content and self._looks_like_mcp_file(content):
+                    files[str(path)] = content
+        return files
+
+    def _should_scan(self, path: Path, root: Path) -> bool:
+        if path.suffix.lower() not in RUST_EXTENSIONS:
+            return False
+        rel = path.relative_to(root)
+        if set(rel.parts) & DEFAULT_SKIP_PATH_PARTS:
+            return False
+        if any(part in self.config.exclude_dirs for part in rel.parts):
+            return False
+        rel_str = str(rel)
+        if self.config.exclude_globs and any(fnmatch(rel_str, g) for g in self.config.exclude_globs):
+            return False
+        if self.config.include_globs:
+            non_rust_only = all(not g.endswith(".rs") for g in self.config.include_globs)
+            if non_rust_only:
+                return True
+            if not any(fnmatch(rel_str, g) for g in self.config.include_globs):
+                return False
+        try:
+            if path.stat().st_size > self.config.max_file_bytes:
+                return False
+        except OSError:
+            return False
+        return True
+
+    def _read_file(self, path: Path) -> str:
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return ""
+
+    def _looks_like_mcp_file(self, content: str) -> bool:
+        return any(indicator in content for indicator in MCP_FILE_INDICATORS)
+
+    def _parse_tools_from_file(self, file_path: Path) -> list[MCPTool]:
+        content = self._read_file(file_path)
+        if not content:
+            return []
+        return self._parse_tools_from_content(file_path, content)
+
+    def _parse_tools_from_content(self, file_path: Path, content: str) -> list[MCPTool]:
+        tools: list[MCPTool] = []
+        for pattern in (TOOL_NEW_PATTERN, TOOL_MACRO_PATTERN):
+            for match in pattern.finditer(content):
+                tool_name = match.group(1)
+                line = content[: match.start()].count("\n") + 1
+                window = content[match.start() : match.start() + 1200]
+                description = _first_match(DESCRIPTION_PATTERN, window) or ""
+                tool = MCPTool(
+                    name=tool_name,
+                    description=description,
+                    input_schema={"type": "object", "properties": {}},
+                    source_file=str(file_path),
+                    source_line=line,
+                    handler_snippet=_handler_snippet(content, match.start()),
+                )
+                tool.capability = infer_capability(tool)
+                tools.append(tool)
+        tools.extend(self._tools_from_match_arms(file_path, content, tools))
+        return tools
+
+    def _tools_from_match_arms(
+        self, file_path: Path, content: str, existing: list[MCPTool]
+    ) -> list[MCPTool]:
+        if "CallToolRequest" not in content and "call_tool" not in content:
+            return []
+        known = {tool.name for tool in existing}
+        tools: list[MCPTool] = []
+        for match in MATCH_ARM_PATTERN.finditer(content):
+            tool_name = match.group(1)
+            if tool_name in known:
+                continue
+            line = content[: match.start()].count("\n") + 1
+            tool = MCPTool(
+                name=tool_name,
+                source_file=str(file_path),
+                source_line=line,
+                handler_snippet=_handler_snippet(content, match.start(), max_lines=30),
+            )
+            tool.capability = infer_capability(tool)
+            tools.append(tool)
+            known.add(tool_name)
+        return tools
+
+
+def _dedupe_tools(tools: list[MCPTool]) -> list[MCPTool]:
+    by_name: dict[str, MCPTool] = {}
+    for tool in tools:
+        existing = by_name.get(tool.name)
+        if existing is None or _tool_richness(tool) > _tool_richness(existing):
+            by_name[tool.name] = tool
+    return list(by_name.values())
+
+
+def _tool_richness(tool: MCPTool) -> int:
+    score = len(tool.input_schema.get("properties", {}))
+    score += 2 if tool.description else 0
+    score += 2 if tool.handler_snippet else 0
+    return score
+
+
+def _first_match(pattern: re.Pattern[str], text: str) -> str | None:
+    match = pattern.search(text)
+    return match.group(1) if match else None
+
+
+def _handler_snippet(content: str, start: int, max_lines: int = 40) -> str:
+    line_start = content.rfind("\n", 0, start) + 1
+    lines = content[line_start:].splitlines()[:max_lines]
+    return "\n".join(lines)

--- a/tests/test_static_go_rust_discovery.py
+++ b/tests/test_static_go_rust_discovery.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 from mcts.core.config import ScanConfig
 from mcts.discovery.static_go import GoStaticDiscovery
-from mcts.discovery.static_rust import RustStaticDiscovery
 from mcts.discovery.static_runner import discover_static
+from mcts.discovery.static_rust import RustStaticDiscovery
 
 ROOT = Path(__file__).resolve().parents[1]
 GO_BENCH = ROOT / "examples" / "bench" / "go-mcp-server"

--- a/tests/test_static_go_rust_discovery.py
+++ b/tests/test_static_go_rust_discovery.py
@@ -1,0 +1,37 @@
+"""Tests for Go and Rust static MCP discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcts.core.config import ScanConfig
+from mcts.discovery.static_go import GoStaticDiscovery
+from mcts.discovery.static_rust import RustStaticDiscovery
+from mcts.discovery.static_runner import discover_static
+
+ROOT = Path(__file__).resolve().parents[1]
+GO_BENCH = ROOT / "examples" / "bench" / "go-mcp-server"
+RUST_BENCH = ROOT / "examples" / "bench" / "rust-mcp-server"
+
+
+def test_go_static_discovery_finds_registered_tools() -> None:
+    config = ScanConfig(target=GO_BENCH, languages=["go"])
+    info = GoStaticDiscovery(config).discover()
+    names = {tool.name for tool in info.tools}
+    assert "run_shell" in names
+    assert "list_files" in names
+
+
+def test_rust_static_discovery_finds_registered_tools() -> None:
+    config = ScanConfig(target=RUST_BENCH, languages=["rust"])
+    info = RustStaticDiscovery(config).discover()
+    names = {tool.name for tool in info.tools}
+    assert "run_command" in names
+
+
+def test_discover_static_runner_includes_go_and_rust() -> None:
+    config = ScanConfig(target=ROOT / "examples" / "bench", languages=["go", "rust"])
+    info = discover_static(config)
+    names = {tool.name for tool in info.tools}
+    assert "run_shell" in names
+    assert "run_command" in names


### PR DESCRIPTION
## Summary
- Add `GoStaticDiscovery` and `RustStaticDiscovery` with repo-walk patterns for common MCP SDK registrations
- Wire both into `discover_static()` when `go`/`rust` are listed in `--languages`
- Add bench fixtures under `examples/bench/` and regression tests

Closes #67

## Test plan
- [x] `uv run pytest tests/test_static_go_rust_discovery.py` — 3 passed
- [ ] `mcts scan examples/bench/go-mcp-server/ --languages go` discovers tools
- [ ] `mcts scan examples/bench/rust-mcp-server/ --languages rust` discovers tools