### PR TITLE
feat(sast): add optional tree-sitter taint for Go and Rust (#91)

### DIFF
--- a/src/mcts/sast/go/taint.py
+++ b/src/mcts/sast/go/taint.py
@@ -8,19 +8,34 @@ from mcts.sast.go.sinks import detect_go_sinks
 from mcts.sast.python.taint import TaintResult
 
 _PARAM_PATTERN = re.compile(r"func\s+\w+\s*\(([^)]*)\)")
+_SHORT_VAR_PATTERN = re.compile(r"(\w+)\s*:=\s*(\w+)")
 
 
 def analyze_go_taint(source: str) -> TaintResult:
+    """Detect sinks reached by handler parameters (tree-sitter optional)."""
+    try:
+        return _tree_sitter_taint(source)
+    except ImportError:
+        return _regex_taint(source)
+
+
+def _regex_taint(source: str) -> TaintResult:
     params = _extract_params(source)
     tainted = set(params)
-    for match in re.finditer(r"(\w+)\s*:=\s*(\w+)", source):
+    for match in _SHORT_VAR_PATTERN.finditer(source):
         if match.group(2) in tainted:
             tainted.add(match.group(1))
     sinks: list[str] = []
     for sink in detect_go_sinks(source):
-        if any(re.search(rf"\b{re.escape(param)}\b", source) for param in tainted):
+        if _sink_uses_tainted(source, sink, tainted):
             sinks.append(sink)
     return TaintResult(sinks=list(dict.fromkeys(sinks)), tainted_params=params)
+
+
+def _sink_uses_tainted(source: str, sink: str, tainted: set[str]) -> bool:
+    if not tainted:
+        return False
+    return any(re.search(rf"\b{re.escape(param)}\b", source) for param in tainted)
 
 
 def _extract_params(source: str) -> set[str]:
@@ -33,3 +48,57 @@ def _extract_params(source: str) -> set[str]:
         if chunk:
             params.add(chunk.split()[0])
     return params
+
+
+def _tree_sitter_taint(source: str) -> TaintResult:
+    import tree_sitter_go as tsgo
+    from tree_sitter import Language, Parser
+
+    parser = Parser(Language(tsgo.language()))
+    tree = parser.parse(source.encode("utf-8"))
+    root = tree.root_node
+    params = _go_collect_params(root, source)
+    tainted = set(params)
+    tainted |= _go_propagate_assignments(root, source, tainted)
+    sinks = [sink for sink in detect_go_sinks(source) if _sink_uses_tainted(source, sink, tainted)]
+    if sinks and tainted:
+        return TaintResult(sinks=list(dict.fromkeys(sinks)), tainted_params=params)
+    return _regex_taint(source)
+
+
+def _go_collect_params(node: object, source: str) -> set[str]:
+    names: set[str] = set()
+    node_type = getattr(node, "type", "")
+    if node_type == "parameter_declaration":
+        for child in getattr(node, "children", []):
+            if getattr(child, "type", "") == "identifier":
+                names.add(source[child.start_byte : child.end_byte])  # type: ignore[attr-defined]
+    for child in getattr(node, "children", []):
+        names |= _go_collect_params(child, source)
+    return names
+
+
+def _go_propagate_assignments(node: object, source: str, tainted: set[str]) -> set[str]:
+    expanded = set(tainted)
+    node_type = getattr(node, "type", "")
+    if node_type == "short_var_declaration":
+        children = getattr(node, "children", [])
+        identifiers = [
+            source[child.start_byte : child.end_byte]  # type: ignore[attr-defined]
+            for child in children
+            if getattr(child, "type", "") == "identifier"
+        ]
+        if len(identifiers) >= 2 and identifiers[1] in expanded:
+            expanded.add(identifiers[0])
+    if node_type == "assignment_statement":
+        children = getattr(node, "children", [])
+        identifiers = [
+            source[child.start_byte : child.end_byte]  # type: ignore[attr-defined]
+            for child in children
+            if getattr(child, "type", "") == "identifier"
+        ]
+        if len(identifiers) >= 2 and identifiers[1] in expanded:
+            expanded.add(identifiers[0])
+    for child in getattr(node, "children", []):
+        expanded |= _go_propagate_assignments(child, source, expanded)
+    return expanded

--- a/src/mcts/sast/rust/taint.py
+++ b/src/mcts/sast/rust/taint.py
@@ -8,16 +8,34 @@ from mcts.sast.python.taint import TaintResult
 from mcts.sast.rust.sinks import detect_rust_sinks
 
 _FN_PATTERN = re.compile(r"fn\s+\w+\s*\(([^)]*)\)")
+_LET_PATTERN = re.compile(r"let\s+(?:mut\s+)?(\w+)\s*=\s*(\w+)")
 
 
 def analyze_rust_taint(source: str) -> TaintResult:
+    """Detect sinks reached by handler parameters (tree-sitter optional)."""
+    try:
+        return _tree_sitter_taint(source)
+    except ImportError:
+        return _regex_taint(source)
+
+
+def _regex_taint(source: str) -> TaintResult:
     params = _extract_params(source)
     tainted = set(params)
+    for match in _LET_PATTERN.finditer(source):
+        if match.group(2) in tainted:
+            tainted.add(match.group(1))
     sinks: list[str] = []
     for sink in detect_rust_sinks(source):
-        if any(re.search(rf"\b{re.escape(param)}\b", source) for param in tainted):
+        if _sink_uses_tainted(source, sink, tainted):
             sinks.append(sink)
     return TaintResult(sinks=list(dict.fromkeys(sinks)), tainted_params=params)
+
+
+def _sink_uses_tainted(source: str, sink: str, tainted: set[str]) -> bool:
+    if not tainted:
+        return False
+    return any(re.search(rf"\b{re.escape(param)}\b", source) for param in tainted)
 
 
 def _extract_params(source: str) -> set[str]:
@@ -33,3 +51,48 @@ def _extract_params(source: str) -> set[str]:
         if name:
             params.add(name)
     return params
+
+
+def _tree_sitter_taint(source: str) -> TaintResult:
+    import tree_sitter_rust as tsrust
+    from tree_sitter import Language, Parser
+
+    parser = Parser(Language(tsrust.language()))
+    tree = parser.parse(source.encode("utf-8"))
+    root = tree.root_node
+    params = _rust_collect_params(root, source)
+    tainted = set(params)
+    tainted |= _rust_propagate_bindings(root, source, tainted)
+    sinks = [sink for sink in detect_rust_sinks(source) if _sink_uses_tainted(source, sink, tainted)]
+    if sinks and tainted:
+        return TaintResult(sinks=list(dict.fromkeys(sinks)), tainted_params=params)
+    return _regex_taint(source)
+
+
+def _rust_collect_params(node: object, source: str) -> set[str]:
+    names: set[str] = set()
+    node_type = getattr(node, "type", "")
+    if node_type == "parameter":
+        for child in getattr(node, "children", []):
+            if getattr(child, "type", "") == "identifier":
+                names.add(source[child.start_byte : child.end_byte])  # type: ignore[attr-defined]
+    for child in getattr(node, "children", []):
+        names |= _rust_collect_params(child, source)
+    return names
+
+
+def _rust_propagate_bindings(node: object, source: str, tainted: set[str]) -> set[str]:
+    expanded = set(tainted)
+    node_type = getattr(node, "type", "")
+    if node_type == "let_declaration":
+        children = getattr(node, "children", [])
+        identifiers = [
+            source[child.start_byte : child.end_byte]  # type: ignore[attr-defined]
+            for child in children
+            if getattr(child, "type", "") == "identifier"
+        ]
+        if len(identifiers) >= 2 and identifiers[1] in expanded:
+            expanded.add(identifiers[0])
+    for child in getattr(node, "children", []):
+        expanded |= _rust_propagate_bindings(child, source, expanded)
+    return expanded

--- a/tests/test_behavioral_eval.py
+++ b/tests/test_behavioral_eval.py
@@ -51,11 +51,23 @@ def test_go_taint_detects_exec_command() -> None:
     assert "cmd" in result.tainted_params
 
 
+def test_go_taint_propagates_short_var() -> None:
+    source = "func run(input string) error { x := input; return exec.Command(x).Run() }"
+    result = analyze_go_taint(source)
+    assert "exec.Command" in result.sinks
+
+
 def test_rust_taint_detects_command_new() -> None:
     source = "fn run(cmd: &str) { Command::new(cmd).spawn(); }"
     result = analyze_rust_taint(source)
     assert "Command::new" in result.sinks
     assert "cmd" in result.tainted_params
+
+
+def test_rust_taint_propagates_let_binding() -> None:
+    source = "fn run(input: &str) { let arg = input; Command::new(arg).spawn(); }"
+    result = analyze_rust_taint(source)
+    assert "Command::new" in result.sinks
 
 
 def test_behavioral_static_go_mismatch() -> None:


### PR DESCRIPTION
## Summary
- Implement optional tree-sitter taint analysis for Go and Rust, mirroring the TypeScript try/fallback pattern
- Propagate short-var and let bindings before sink matching
- Fall back to regex when `[sast]` extras are not installed

Closes #91

## Test plan
- [x] `uv run pytest tests/test_behavioral_eval.py` — 8 passed
- [ ] With `uv sync --extra sast`, verify tree-sitter path on non-trivial handlers