### PR TITLE
Rust rmcp tool discovery and auto language detection (#121)

### DIFF
--- a/examples/bench/rust-mcp-rmcp/src/lib.rs
+++ b/examples/bench/rust-mcp-rmcp/src/lib.rs
@@ -1,0 +1,20 @@
+//! rmcp-style MCP server fixture for static discovery tests.
+
+use rmcp::{tool, tool_router};
+
+#[derive(Clone)]
+pub struct DemoServer;
+
+#[tool_router(server_handler)]
+impl DemoServer {
+    #[tool(description = "Run shell command from user input")]
+    async fn run_shell(&self) -> String {
+        std::process::Command::new("sh").spawn().ok();
+        "ok".into()
+    }
+
+    #[tool(name = "list_files", description = "List directory entries")]
+    async fn list_dir(&self) -> String {
+        "[]".into()
+    }
+}

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -75,6 +75,25 @@ def _print_discovery_warnings(server, stderr_file: str | None) -> None:
         )
 
 
+def _check_strict_discovery(report, config: ScanConfig) -> None:
+    if not config.strict_discovery:
+        return
+    from mcts.reporting.models import Severity
+
+    incomplete = [
+        finding
+        for finding in report.findings
+        if finding.analyzer == "static_discovery"
+        and finding.severity in {Severity.HIGH, Severity.CRITICAL}
+    ]
+    if not incomplete:
+        return
+    console.print("[red]Error:[/red] --strict-discovery: static tool discovery looks incomplete.")
+    for finding in incomplete:
+        console.print(f"  [red]•[/red] {finding.title}")
+    raise typer.Exit(code=2)
+
+
 def _check_strict_live(report, config: ScanConfig) -> None:
     if not config.strict_live:
         return
@@ -240,7 +259,7 @@ def scan(
         str | None,
         typer.Option(
             "--languages",
-            help="Comma-separated discovery languages: python, typescript (default: both)",
+            help="Comma-separated discovery languages: python, typescript, go, rust (auto-detects go/rust in repos)",
         ),
     ] = None,
     baseline: Annotated[
@@ -345,6 +364,13 @@ def scan(
         typer.Option(
             "--strict-live",
             help="Exit 2 when live discovery is incomplete (e.g. list_tools failed after initialize)",
+        ),
+    ] = False,
+    strict_discovery: Annotated[
+        bool,
+        typer.Option(
+            "--strict-discovery",
+            help="Exit 2 when static discovery finds MCP sources but zero tools",
         ),
     ] = False,
     enable_yara: Annotated[
@@ -539,11 +565,12 @@ def scan(
 
     scan_target = config if (config and target == Path(".")) else target
     live_args = [part.strip() for part in args.split(",") if part.strip()] if args else []
-    language_list = (
-        [part.strip() for part in languages.split(",") if part.strip()]
-        if languages
-        else ["python", "typescript"]
-    )
+    if languages:
+        language_list = [part.strip() for part in languages.split(",") if part.strip()]
+    else:
+        from mcts.discovery.language_detect import resolve_default_languages
+
+        language_list = resolve_default_languages(Path(scan_target))
     surface_list = (
         [part.strip() for part in surfaces.split(",") if part.strip()]
         if surfaces
@@ -645,6 +672,7 @@ def scan(
         protocol_probe=protocol_probe,
         stderr_file=stderr_file,
         strict_live=strict_live,
+        strict_discovery=strict_discovery,
         expand_vars=expand_vars,
         snapshot_path=snapshot,
         pip_audit=pip_audit,
@@ -787,6 +815,7 @@ def scan(
 
     _print_discovery_warnings(report.server, stderr_file)
     _check_strict_live(report, config_obj)
+    _check_strict_discovery(report, config_obj)
     _check_gates(report, config_obj)
     try:
         gov = load_policy(config_obj.governance_policy)

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -83,8 +83,7 @@ def _check_strict_discovery(report, config: ScanConfig) -> None:
     incomplete = [
         finding
         for finding in report.findings
-        if finding.analyzer == "static_discovery"
-        and finding.severity in {Severity.HIGH, Severity.CRITICAL}
+        if finding.analyzer == "static_discovery" and finding.severity in {Severity.HIGH, Severity.CRITICAL}
     ]
     if not incomplete:
         return

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -259,7 +259,10 @@ def scan(
         str | None,
         typer.Option(
             "--languages",
-            help="Comma-separated discovery languages: python, typescript, go, rust (auto-detects go/rust in repos)",
+            help=(
+                "Comma-separated discovery languages: python, typescript, go, rust "
+                "(auto-detects go/rust in repos)"
+            ),
         ),
     ] = None,
     baseline: Annotated[

--- a/src/mcts/core/config.py
+++ b/src/mcts/core/config.py
@@ -75,6 +75,7 @@ class ScanConfig(BaseModel):
     protocol_probe: bool = False
     stderr_file: str | None = None
     strict_live: bool = False
+    strict_discovery: bool = False
     expand_vars: str = "auto"
     # P1 — static snapshot + supply chain
     snapshot_path: Path | None = None

--- a/src/mcts/core/scanner.py
+++ b/src/mcts/core/scanner.py
@@ -179,6 +179,14 @@ class Scanner:
             findings.extend(discovery_meta_findings(server_info))
             analyzers_executed.append("live_discovery")
 
+        if not self.config.live and not self.config.remote_url and not self.config.snapshot_path:
+            from mcts.discovery.static_meta import static_discovery_meta_findings
+
+            static_meta = static_discovery_meta_findings(server_info, self.config)
+            if static_meta:
+                findings.extend(static_meta)
+                analyzers_executed.append("static_discovery")
+
         for analyzer in self.analyzers:
             if not self._is_enabled(analyzer):
                 continue

--- a/src/mcts/discovery/language_detect.py
+++ b/src/mcts/discovery/language_detect.py
@@ -1,0 +1,83 @@
+"""Detect repository languages for static MCP discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcts.core.config import DEFAULT_EXCLUDE_DIRS
+
+DEFAULT_LANGUAGES = ("python", "typescript")
+
+GO_MCP_INDICATORS = (
+    "AddTool(",
+    "RegisterTool(",
+    "github.com/modelcontextprotocol/go-sdk",
+    "github.com/mark3labs/mcp-go",
+)
+
+RUST_MCP_INDICATORS = (
+    "rmcp::",
+    "mcp_server::",
+    "#[tool",
+    "tool_router",
+    "CallToolRequest",
+    "ListToolsRequest",
+)
+
+
+def detect_repo_languages(
+    root: Path,
+    *,
+    exclude_dirs: frozenset[str] | set[str] | None = None,
+) -> set[str]:
+    """Infer extra discovery languages from repository contents."""
+    if not root.is_dir():
+        return set()
+
+    skip = frozenset(exclude_dirs or DEFAULT_EXCLUDE_DIRS)
+    detected: set[str] = set()
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(root).parts
+        if set(rel_parts) & skip:
+            continue
+
+        suffix = path.suffix.lower()
+        if suffix == ".go" and _file_has_indicators(path, GO_MCP_INDICATORS):
+            detected.add("go")
+        elif suffix == ".rs" and _file_has_indicators(path, RUST_MCP_INDICATORS):
+            detected.add("rust")
+        elif path.name == "Cargo.toml" and _file_has_indicators(path, ("rmcp", "mcp_server")):
+            detected.add("rust")
+
+    return detected
+
+
+def resolve_default_languages(
+    target: Path,
+    *,
+    exclude_dirs: frozenset[str] | set[str] | None = None,
+) -> list[str]:
+    """Return default scan languages plus any detected from the target path."""
+    ordered = list(DEFAULT_LANGUAGES)
+    if target.is_dir():
+        for lang in sorted(detect_repo_languages(target, exclude_dirs=exclude_dirs)):
+            if lang not in ordered:
+                ordered.append(lang)
+    elif target.suffix.lower() == ".go":
+        ordered.append("go")
+    elif target.suffix.lower() == ".rs":
+        ordered.append("rust")
+    return ordered
+
+
+def _file_has_indicators(path: Path, indicators: tuple[str, ...]) -> bool:
+    try:
+        if path.stat().st_size > 500_000:
+            return False
+        content = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return any(indicator in content for indicator in indicators)

--- a/src/mcts/discovery/language_detect.py
+++ b/src/mcts/discovery/language_detect.py
@@ -47,9 +47,9 @@ def detect_repo_languages(
         suffix = path.suffix.lower()
         if suffix == ".go" and _file_has_indicators(path, GO_MCP_INDICATORS):
             detected.add("go")
-        elif suffix == ".rs" and _file_has_indicators(path, RUST_MCP_INDICATORS):
-            detected.add("rust")
-        elif path.name == "Cargo.toml" and _file_has_indicators(path, ("rmcp", "mcp_server")):
+        elif (suffix == ".rs" and _file_has_indicators(path, RUST_MCP_INDICATORS)) or (
+            path.name == "Cargo.toml" and _file_has_indicators(path, ("rmcp", "mcp_server"))
+        ):
             detected.add("rust")
 
     return detected

--- a/src/mcts/discovery/static_meta.py
+++ b/src/mcts/discovery/static_meta.py
@@ -1,0 +1,92 @@
+"""Meta-findings for incomplete static MCP discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcts.core.config import ScanConfig
+from mcts.core.target import ScanTarget, TargetKind
+from mcts.discovery.language_detect import RUST_MCP_INDICATORS, detect_repo_languages
+from mcts.mcp.models import MCPServerInfo
+from mcts.reporting.models import Finding, Severity
+
+
+def static_discovery_meta_findings(server: MCPServerInfo, config: ScanConfig) -> list[Finding]:
+    """Emit findings when static discovery likely missed MCP tools."""
+    if server.tools:
+        return []
+    if config.live or config.remote_url or config.snapshot_path:
+        return []
+
+    target = ScanTarget(config.target)
+    if target.kind != TargetKind.DIRECTORY:
+        return []
+
+    langs = {language.lower() for language in config.languages}
+    detected = detect_repo_languages(target.path, exclude_dirs=frozenset(config.exclude_dirs))
+    rust_sources = _rust_mcp_sources_present(target.path, config.exclude_dirs)
+
+    if rust_sources and ("rust" in langs or "rs" in langs):
+        return [
+            Finding(
+                id="static-discovery-rust-incomplete",
+                analyzer="static_discovery",
+                title="Rust MCP sources found but no tools discovered",
+                description=(
+                    "The repository contains Rust MCP indicators but static discovery "
+                    "returned zero tools. Handler analysis and behavioral SAST did not run."
+                ),
+                severity=Severity.HIGH,
+                recommendation=(
+                    "Verify rmcp #[tool] registration patterns are supported, pass "
+                    "--languages rust, or use --live --i-understand-live-risk for live discovery."
+                ),
+                technique_id="MCTS-T-1001",
+                confidence=0.9,
+                evidence={
+                    "languages": sorted(langs),
+                    "detected_languages": sorted(detected),
+                    "discovery_mode": server.discovery_mode,
+                },
+            )
+        ]
+
+    if detected & langs:
+        return [
+            Finding(
+                id="static-discovery-incomplete",
+                analyzer="static_discovery",
+                title="Static MCP tool discovery returned zero tools",
+                description=(
+                    "MCP source indicators were found for enabled languages but no tools "
+                    "were discovered. Security analysis may be incomplete."
+                ),
+                severity=Severity.MEDIUM,
+                recommendation=(
+                    "Use --live --i-understand-live-risk, export a tools/list snapshot, "
+                    "or verify static discovery supports your SDK registration patterns."
+                ),
+                confidence=0.8,
+                evidence={
+                    "languages": sorted(langs),
+                    "detected_languages": sorted(detected),
+                    "discovery_mode": server.discovery_mode,
+                },
+            )
+        ]
+    return []
+
+
+def _rust_mcp_sources_present(root: Path, exclude_dirs: list[str]) -> bool:
+    skip = frozenset(exclude_dirs)
+    for path in root.rglob("*.rs"):
+        rel_parts = path.relative_to(root).parts
+        if set(rel_parts) & skip:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if any(indicator in content for indicator in RUST_MCP_INDICATORS):
+            return True
+    return False

--- a/src/mcts/discovery/static_rust.py
+++ b/src/mcts/discovery/static_rust.py
@@ -20,6 +20,8 @@ MCP_FILE_INDICATORS = (
     "Tool::new",
     "Server::tool",
     ".tool(",
+    "#[tool",
+    "tool_router",
     "ListToolsRequest",
     "CallToolRequest",
     "call_tool",
@@ -42,6 +44,12 @@ DESCRIPTION_PATTERN = re.compile(
 MATCH_ARM_PATTERN = re.compile(
     r"[\"']([^\"']+)[\"']\s*=>\s*\{",
 )
+TOOL_ATTR_PATTERN = re.compile(
+    r"#\[tool(?:\((?P<attrs>[^)]*)\))?\]\s*(?:pub\s+)?(?:async\s+)?fn\s+(?P<fn>\w+)",
+    re.MULTILINE,
+)
+ATTR_NAME_PATTERN = re.compile(r"""name\s*=\s*["']([^"']+)["']""")
+ATTR_DESC_PATTERN = re.compile(r"""description\s*=\s*["']([^"']+)["']""")
 
 
 class RustStaticDiscovery:
@@ -151,6 +159,33 @@ class RustStaticDiscovery:
                 tool.capability = infer_capability(tool)
                 tools.append(tool)
         tools.extend(self._tools_from_match_arms(file_path, content, tools))
+        tools.extend(self._tools_from_tool_attrs(file_path, content, tools))
+        return tools
+
+    def _tools_from_tool_attrs(
+        self, file_path: Path, content: str, existing: list[MCPTool]
+    ) -> list[MCPTool]:
+        known = {tool.name for tool in existing}
+        tools: list[MCPTool] = []
+        for match in TOOL_ATTR_PATTERN.finditer(content):
+            attrs = match.group("attrs") or ""
+            fn_name = match.group("fn")
+            tool_name = _first_match(ATTR_NAME_PATTERN, attrs) or fn_name
+            if tool_name in known:
+                continue
+            line = content[: match.start()].count("\n") + 1
+            description = _first_match(ATTR_DESC_PATTERN, attrs) or ""
+            tool = MCPTool(
+                name=tool_name,
+                description=description,
+                input_schema={"type": "object", "properties": {}},
+                source_file=str(file_path),
+                source_line=line,
+                handler_snippet=_handler_snippet(content, match.start()),
+            )
+            tool.capability = infer_capability(tool)
+            tools.append(tool)
+            known.add(tool_name)
         return tools
 
     def _tools_from_match_arms(self, file_path: Path, content: str, existing: list[MCPTool]) -> list[MCPTool]:

--- a/src/mcts/discovery/static_rust.py
+++ b/src/mcts/discovery/static_rust.py
@@ -162,9 +162,7 @@ class RustStaticDiscovery:
         tools.extend(self._tools_from_tool_attrs(file_path, content, tools))
         return tools
 
-    def _tools_from_tool_attrs(
-        self, file_path: Path, content: str, existing: list[MCPTool]
-    ) -> list[MCPTool]:
+    def _tools_from_tool_attrs(self, file_path: Path, content: str, existing: list[MCPTool]) -> list[MCPTool]:
         known = {tool.name for tool in existing}
         tools: list[MCPTool] = []
         for match in TOOL_ATTR_PATTERN.finditer(content):

--- a/tests/test_static_discovery_meta.py
+++ b/tests/test_static_discovery_meta.py
@@ -1,0 +1,39 @@
+"""Tests for static discovery meta-findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcts.core.config import ScanConfig
+from mcts.core.scanner import Scanner
+from mcts.discovery.static_meta import static_discovery_meta_findings
+from mcts.mcp.models import MCPServerInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+RUST_RMCP_BENCH = ROOT / "examples" / "bench" / "rust-mcp-rmcp"
+
+
+def test_static_meta_when_rust_sources_but_no_tools() -> None:
+    server = MCPServerInfo(name="demo", tools=[], discovery_mode="static")
+    config = ScanConfig(target=RUST_RMCP_BENCH, languages=["python", "typescript"])
+    findings = static_discovery_meta_findings(server, config)
+    assert not findings
+
+
+def test_static_meta_emits_when_rust_enabled_but_zero_tools() -> None:
+    server = MCPServerInfo(name="demo", tools=[], discovery_mode="static")
+    config = ScanConfig(target=RUST_RMCP_BENCH, languages=["rust"])
+    findings = static_discovery_meta_findings(server, config)
+    assert any(f.analyzer == "static_discovery" for f in findings)
+
+
+def test_rmcp_repo_scan_discovers_tools_without_explicit_language_flag() -> None:
+    from mcts.discovery.language_detect import resolve_default_languages
+
+    config = ScanConfig(
+        target=RUST_RMCP_BENCH,
+        languages=resolve_default_languages(RUST_RMCP_BENCH),
+    )
+    report = Scanner(config).run()
+    assert report.server.tools
+    assert not any(f.id == "static-discovery-rust-incomplete" for f in report.findings)

--- a/tests/test_static_go_rust_discovery.py
+++ b/tests/test_static_go_rust_discovery.py
@@ -12,6 +12,7 @@ from mcts.discovery.static_rust import RustStaticDiscovery
 ROOT = Path(__file__).resolve().parents[1]
 GO_BENCH = ROOT / "examples" / "bench" / "go-mcp-server"
 RUST_BENCH = ROOT / "examples" / "bench" / "rust-mcp-server"
+RUST_RMCP_BENCH = ROOT / "examples" / "bench" / "rust-mcp-rmcp"
 
 
 def test_go_static_discovery_finds_registered_tools() -> None:
@@ -35,3 +36,18 @@ def test_discover_static_runner_includes_go_and_rust() -> None:
     names = {tool.name for tool in info.tools}
     assert "run_shell" in names
     assert "run_command" in names
+
+
+def test_rust_macro_discovery_finds_rmcp_tools() -> None:
+    config = ScanConfig(target=RUST_RMCP_BENCH, languages=["rust"])
+    info = RustStaticDiscovery(config).discover()
+    names = {tool.name for tool in info.tools}
+    assert "run_shell" in names
+    assert "list_files" in names
+
+
+def test_default_language_detect_includes_rust_for_rmcp_repo() -> None:
+    from mcts.discovery.language_detect import resolve_default_languages
+
+    langs = resolve_default_languages(RUST_RMCP_BENCH)
+    assert "rust" in langs


### PR DESCRIPTION
## Summary
- Auto-detect `go`/`rust` languages from repo contents when `--languages` is not passed
- Parse rmcp `#[tool]` macro registration patterns during static discovery
- Emit scorable `static_discovery` findings when MCP sources exist but zero tools are found
- Add `--strict-discovery` CI gate and rmcp fixture under `examples/bench/rust-mcp-rmcp/`

Fixes #121

## Test plan
- [x] `pytest tests/test_static_go_rust_discovery.py tests/test_static_discovery_meta.py`
- [ ] `mcts scan examples/bench/rust-mcp-rmcp/` discovers tools without `--languages rust`