### PR TITLE
Pin GitHub Action install to uv.lock with configurable extras (#77, #69)

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -42,7 +42,7 @@ jobs:
 
 ## What the action does
 
-1. Installs MCTS from the pinned action ref (`pip install` from the checked-out `MCTS` repo — not PyPI), so the action version always matches the scanner
+1. Installs MCTS with `uv sync --frozen` from the pinned action ref (reproducible lockfile; default extras: `mcp`, `sast`)
 2. Runs `mcts scan` on your target
 3. Writes `mcts-report.json` and `mcts-report.sarif`
 4. Generates `mcts-report.html` via `mcts report`
@@ -50,6 +50,16 @@ jobs:
 6. Fails the workflow if `fail-on-critical` or `min-score` thresholds are not met
 
 You upload SARIF separately (step 2 above) to show findings in GitHub's Security tab.
+
+### Installed capabilities (default extras)
+
+| Feature | Extra | Default action |
+|---------|-------|----------------|
+| Python / TS static scan | core | Yes |
+| Live probe (`--live`) | `mcp` | Yes |
+| Tree-sitter SAST (TS/Go/Rust) | `sast` | Yes |
+| `--pip-audit` | `supplychain` | Opt-in via `extras` input |
+| `--yara`, `--llm-judge`, `--semgrep` | respective extras | Opt-in via `extras` input |
 
 ---
 
@@ -74,6 +84,7 @@ If the action lives in your repo under `action/`:
 | `target` | `./server.py` | Path to MCP server entrypoint or repo directory |
 | `fail-on-critical` | `true` | Fail workflow if any critical finding is detected |
 | `min-score` | — | Fail if overall score is below this threshold (0–100) |
+| `extras` | `mcp,sast` | Comma-separated optional extras (`all` installs every extra) |
 
 ---
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -17,23 +17,46 @@ inputs:
     description: Fail if security score is below this value (0-100). Leave empty to skip.
     required: false
     default: ""
+  extras:
+    description: >
+      Comma-separated pyproject optional extras (mcp, sast, supplychain, yara,
+      llm, semgrep, api, all). Default installs mcp and sast for live probe and
+      tree-sitter SAST.
+    required: false
+    default: "mcp,sast"
 
 runs:
   using: composite
   steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.12"
+        enable-cache: true
 
     - name: Install MCTS
       shell: bash
-      # Install from the action's checked-out ref so the action version always
-      # matches the scanner code (works before and after PyPI publish).
-      run: pip install "${{ github.action_path }}/.."
+      working-directory: ${{ github.action_path }}/..
+      run: |
+        set -euo pipefail
+        EXTRAS="${{ inputs.extras }}"
+        if [ "$EXTRAS" = "all" ]; then
+          uv sync --frozen --no-dev --all-extras
+        else
+          ARGS=()
+          IFS=',' read -ra PARTS <<< "$EXTRAS"
+          for extra in "${PARTS[@]}"; do
+            trimmed="$(echo "$extra" | xargs)"
+            if [ -n "$trimmed" ]; then
+              ARGS+=(--extra "$trimmed")
+            fi
+          done
+          uv sync --frozen --no-dev "${ARGS[@]}"
+        fi
 
     - name: Run security scan
       shell: bash
+      working-directory: ${{ github.action_path }}/..
       run: |
         set -euo pipefail
         TARGET="${{ inputs.target }}"
@@ -48,12 +71,13 @@ runs:
           ARGS+=(--min-score "${{ inputs.min-score }}")
         fi
 
-        mcts "${ARGS[@]}"
-        mcts scan "$TARGET" --no-progress --format sarif -o "$SARIF_OUT"
+        uv run mcts "${ARGS[@]}"
+        uv run mcts scan "$TARGET" --no-progress --format sarif -o "$SARIF_OUT"
 
     - name: Generate HTML dashboard
       shell: bash
-      run: mcts report "${{ github.workspace }}/mcts-report.json" -o "${{ github.workspace }}/mcts-report.html"
+      working-directory: ${{ github.action_path }}/..
+      run: uv run mcts report "${{ github.workspace }}/mcts-report.json" -o "${{ github.workspace }}/mcts-report.html"
 
     - name: Upload JSON report
       if: always()

--- a/docs/platform/ci-integration.md
+++ b/docs/platform/ci-integration.md
@@ -66,7 +66,7 @@ jobs:
 
 ### What the action does
 
-1. Installs MCTS from the **pinned action ref** (the checked-out `MCTS` tag/commit), not from PyPI — so `@v1` always runs the matching scanner code
+1. Installs MCTS with **`uv sync --frozen`** from the pinned action ref (lockfile-pinned deps; default extras `mcp`, `sast`)
 2. Runs `mcts scan` on `target`
 3. Writes `mcts-report.json` and `mcts-report.sarif`
 4. Runs `mcts report` → `mcts-report.html`
@@ -83,6 +83,7 @@ Full reference: [action/README.md](../../action/README.md)
 | `target` | `./server.py` | Scan target path |
 | `fail-on-critical` | `true` | Fail workflow on critical findings |
 | `min-score` | — | Fail if score below threshold |
+| `extras` | `mcp,sast` | Optional extras to install (`all` for full set) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace unpinned `pip install .` with `uv sync --frozen --no-dev` from the action ref lockfile
- Add `extras` action input (default `mcp,sast`) for live probe and tree-sitter SAST
- Document capability matrix in action README and CI integration guide

Fixes #77
Fixes #69

## Test plan
- [ ] Validate Action workflow passes on this PR
- [ ] Consumer workflow with `extras: supplychain` installs pip-audit extra