### PR TITLE
Paginate batch API scans and document rate limits (#86)

### DIFF
--- a/docs/platform/rest-api.md
+++ b/docs/platform/rest-api.md
@@ -99,8 +99,24 @@ All scan endpoints accept these fields (plus endpoint-specific fields where note
 | `hide_safe` | bool | `false` | Omit low-severity informational findings |
 | `tool_filter` | string[] | `[]` | Limit scan to named tools |
 | `analyzer_filter` | string[] | `[]` | Limit output to named analyzers |
+| `fanout_offset` | int | `0` | Pagination offset for batch scan endpoints |
+| `fanout_limit` | int | env max (50) | Page size for batch scan endpoints |
 
-Endpoint-specific fields:
+Batch endpoints (`/scan-all-tools`, `/scan-all-prompts`, `/scan-all-resources`) run one full analyzer pass per item. Use `fanout_offset` and `fanout_limit` to paginate; responses include `truncated` and `truncation_warning` when more items remain.
+
+---
+
+## Rate limits
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCTS_API_RATE_LIMIT_PER_MINUTE` | 30 | Per-client POST rate limit |
+| `MCTS_API_MAX_BODY_BYTES` | 1048576 | Max request body size |
+| `MCTS_API_MAX_CONCURRENT_SCANS` | 2 | Concurrent scan workers |
+| `MCTS_API_MAX_FANOUT_ITEMS` | 50 | Max items per batch page |
+| `MCTS_API_SCAN_TIMEOUT_SECONDS` | 300 | Per-scan timeout |
+
+---
 
 | Endpoint | Extra fields |
 |----------|--------------|

--- a/src/mcts/api/app.py
+++ b/src/mcts/api/app.py
@@ -12,7 +12,7 @@ from mcts.api import limits
 from mcts.api.auth import require_api_key
 from mcts.api.limits import (
     RequestLimitsMiddleware,
-    cap_fanout,
+    paginate_fanout,
     run_scan_with_limits,
 )
 from mcts.core.config import ScanConfig
@@ -51,6 +51,8 @@ class ScanRequest(BaseModel):
     runtime_events: list[dict[str, Any]] = Field(default_factory=list)
     fail_on_critical: bool = False
     min_score: int | None = Field(default=None, ge=0, le=100)
+    fanout_offset: int = Field(default=0, ge=0)
+    fanout_limit: int | None = Field(default=None, ge=1)
 
     @field_validator("runtime_events")
     @classmethod
@@ -190,16 +192,23 @@ async def scan_tool(req: ToolScanRequest) -> dict[str, Any]:
 
 @app.post("/scan-all-tools", dependencies=_auth)
 async def scan_all_tools(req: ScanRequest) -> dict[str, Any]:
+    """Scan each discovered tool separately. Use fanout_offset/limit to paginate."""
     server = await _discover_async(req)
-    tools = cap_fanout(server.tools, label="tools")
+    page = paginate_fanout(
+        server.tools,
+        offset=req.fanout_offset,
+        limit=req.fanout_limit,
+        label="tools",
+    )
     reports = []
-    for tool in tools:
+    for tool in page.items:
         filtered = _filter_server(server, tool_name=tool.name)
         reports.append(await _scan_server_async(req, filtered))
     return {
         "server_url": req.url or req.target,
-        "tool_count": len(tools),
+        "tool_count": page.total,
         "reports": reports,
+        **page.metadata(label="tools"),
     }
 
 
@@ -216,15 +225,23 @@ async def scan_prompt(req: PromptScanRequest) -> dict[str, Any]:
 
 @app.post("/scan-all-prompts", dependencies=_auth)
 async def scan_all_prompts(req: ScanRequest) -> dict[str, Any]:
+    """Scan each prompt separately. Use fanout_offset/limit to paginate."""
     server = await _discover_async(req)
-    prompts = cap_fanout(server.prompts, label="prompts")
+    page = paginate_fanout(
+        server.prompts,
+        offset=req.fanout_offset,
+        limit=req.fanout_limit,
+        label="prompts",
+    )
     reports = [
-        await _scan_server_async(req, _filter_server(server, prompt_name=prompt.name)) for prompt in prompts
+        await _scan_server_async(req, _filter_server(server, prompt_name=prompt.name))
+        for prompt in page.items
     ]
     return {
         "server_url": req.url or req.target,
-        "total_prompts": len(prompts),
+        "total_prompts": page.total,
         "reports": reports,
+        **page.metadata(label="prompts"),
     }
 
 
@@ -241,16 +258,23 @@ async def scan_resource(req: ResourceScanRequest) -> dict[str, Any]:
 
 @app.post("/scan-all-resources", dependencies=_auth)
 async def scan_all_resources(req: ScanRequest) -> dict[str, Any]:
+    """Scan each resource separately. Use fanout_offset/limit to paginate."""
     server = await _discover_async(req)
-    resources = cap_fanout(server.resources, label="resources")
+    page = paginate_fanout(
+        server.resources,
+        offset=req.fanout_offset,
+        limit=req.fanout_limit,
+        label="resources",
+    )
     reports = [
         await _scan_server_async(req, _filter_server(server, resource_uri=resource.uri))
-        for resource in resources
+        for resource in page.items
     ]
     return {
         "server_url": req.url or req.target,
-        "total_resources": len(resources),
+        "total_resources": page.total,
         "reports": reports,
+        **page.metadata(label="resources"),
     }
 
 

--- a/src/mcts/api/limits.py
+++ b/src/mcts/api/limits.py
@@ -8,6 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 from fastapi import HTTPException, Request
@@ -20,6 +21,31 @@ DEFAULT_MAX_FANOUT_ITEMS = 50
 DEFAULT_RATE_LIMIT_PER_MINUTE = 30
 DEFAULT_MAX_LIST_ITEMS = 100
 DEFAULT_MAX_RUNTIME_EVENTS = 500
+DEFAULT_SCAN_TIMEOUT_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class PaginatedFanout:
+    items: list[Any]
+    total: int
+    offset: int
+    limit: int
+    truncated: bool
+
+    def metadata(self, *, label: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            f"total_{label}": self.total,
+            "returned": len(self.items),
+            "offset": self.offset,
+            "limit": self.limit,
+            "truncated": self.truncated,
+        }
+        if self.truncated:
+            payload["truncation_warning"] = (
+                f"Scanned {len(self.items)} of {self.total} {label}; "
+                f"set fanout_offset={self.offset + self.limit} for the next page."
+            )
+        return payload
 
 
 class _ScanConcurrencyState:
@@ -64,6 +90,10 @@ def max_list_items() -> int:
 
 def max_runtime_events() -> int:
     return _env_int("MCTS_API_MAX_RUNTIME_EVENTS", DEFAULT_MAX_RUNTIME_EVENTS)
+
+
+def scan_timeout_seconds() -> int:
+    return _env_int("MCTS_API_SCAN_TIMEOUT_SECONDS", DEFAULT_SCAN_TIMEOUT_SECONDS)
 
 
 def _scan_semaphore_for(limit: int) -> asyncio.Semaphore:
@@ -159,14 +189,41 @@ async def run_scan_with_limits(func: Callable[[], Any]) -> Any:
 
     async with semaphore:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, func)
+        try:
+            return await asyncio.wait_for(
+                loop.run_in_executor(None, func),
+                timeout=scan_timeout_seconds(),
+            )
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail="Scan timed out; retry later") from exc
+
+
+def paginate_fanout(
+    items: list[Any],
+    *,
+    offset: int,
+    limit: int | None,
+    label: str,
+) -> PaginatedFanout:
+    """Return one page of fan-out items instead of scanning an unbounded list."""
+    total = len(items)
+    if offset > total:
+        raise HTTPException(
+            status_code=400,
+            detail=f"fanout_offset {offset} exceeds total {label} count ({total})",
+        )
+    ceiling = max_fanout_items()
+    page_size = min(limit or ceiling, ceiling)
+    page = items[offset : offset + page_size]
+    return PaginatedFanout(
+        items=page,
+        total=total,
+        offset=offset,
+        limit=page_size,
+        truncated=offset + page_size < total,
+    )
 
 
 def cap_fanout(items: list[Any], *, label: str) -> list[Any]:
-    limit = max_fanout_items()
-    if len(items) > limit:
-        raise HTTPException(
-            status_code=413,
-            detail=f"Too many {label} ({len(items)}); maximum fan-out is {limit}",
-        )
-    return items
+    """Legacy helper — prefer paginate_fanout for batch endpoints."""
+    return paginate_fanout(items, offset=0, limit=None, label=label).items

--- a/tests/test_api_limits.py
+++ b/tests/test_api_limits.py
@@ -1,54 +1,78 @@
-"""Tests for API rate limits, body caps, and scan concurrency."""
+"""Tests for REST API rate limits and fan-out pagination."""
 
 from __future__ import annotations
 
 import pytest
 
+from mcts.api.limits import paginate_fanout, reset_rate_limits_for_tests
+from mcts.mcp.models import MCPServerInfo, MCPTool
 
-def test_api_rejects_oversized_content_length(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def test_paginate_fanout_truncates_with_warning() -> None:
+    items = [object() for _ in range(5)]
+    page = paginate_fanout(items, offset=0, limit=2, label="tools")
+    assert len(page.items) == 2
+    assert page.truncated is True
+    meta = page.metadata(label="tools")
+    assert meta["total_tools"] == 5
+    assert meta["returned"] == 2
+    assert "fanout_offset=2" in meta["truncation_warning"]
+
+
+def test_paginate_fanout_second_page() -> None:
+    items = [object() for _ in range(5)]
+    page = paginate_fanout(items, offset=2, limit=2, label="tools")
+    assert len(page.items) == 2
+    assert page.offset == 2
+
+
+def test_paginate_fanout_rejects_offset_past_total() -> None:
+    pytest.importorskip("fastapi")
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        paginate_fanout([1, 2], offset=5, limit=1, label="tools")
+    assert exc.value.status_code == 400
+
+
+def test_api_scan_all_tools_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("fastapi")
     from fastapi.testclient import TestClient
 
-    from mcts.api import limits
-    from mcts.api.app import app
+    from mcts.api import app as app_module
 
-    monkeypatch.setattr(limits, "max_body_bytes", lambda: 128)
-    client = TestClient(app)
+    tools = [MCPTool(name=f"tool_{index}") for index in range(4)]
+    server = MCPServerInfo(name="mock", tools=tools)
+
+    async def fake_discover(_req):  # noqa: ANN001
+        return server
+
+    monkeypatch.setattr(app_module, "_discover_async", fake_discover)
+    client = TestClient(app_module.app)
     response = client.post(
-        "/scan",
-        json={"target": "."},
-        headers={"Content-Length": "9999"},
+        "/scan-all-tools",
+        json={"target": ".", "fanout_offset": 0, "fanout_limit": 2},
     )
-    assert response.status_code == 413
-
-
-def test_api_rejects_oversized_runtime_events(monkeypatch: pytest.MonkeyPatch) -> None:
-    pytest.importorskip("fastapi")
-    from fastapi.testclient import TestClient
-
-    from mcts.api import limits
-    from mcts.api.app import app
-
-    monkeypatch.setattr(limits, "max_runtime_events", lambda: 2)
-    client = TestClient(app)
-    response = client.post(
-        "/scan",
-        json={"target": ".", "runtime_events": [{}, {}, {}]},
-    )
-    assert response.status_code == 422
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tool_count"] == 4
+    assert payload["returned"] == 2
+    assert payload["truncated"] is True
+    assert len(payload["reports"]) == 2
 
 
 def test_api_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("fastapi")
     from fastapi.testclient import TestClient
 
-    from mcts.api import limits
     from mcts.api.app import app
 
-    limits.reset_rate_limits_for_tests()
-    monkeypatch.setattr(limits, "rate_limit_per_minute", lambda: 1)
+    monkeypatch.setenv("MCTS_API_RATE_LIMIT_PER_MINUTE", "2")
+    reset_rate_limits_for_tests()
     client = TestClient(app)
-    first = client.post("/readiness", json={"target": "."})
-    second = client.post("/readiness", json={"target": "."})
-    assert first.status_code == 200
-    assert second.status_code == 429
+    assert client.get("/health").status_code == 200
+    assert client.post("/readiness", json={"target": "."}).status_code == 200
+    assert client.post("/readiness", json={"target": "."}).status_code == 200
+    blocked = client.post("/readiness", json={"target": "."})
+    assert blocked.status_code == 429
+    reset_rate_limits_for_tests()


### PR DESCRIPTION
## Summary
- Add `fanout_offset` and `fanout_limit` pagination to batch scan endpoints with truncation metadata
- Replace hard 413 fan-out rejection with paginated responses
- Add per-scan timeout via `MCTS_API_SCAN_TIMEOUT_SECONDS`
- Document rate limit env vars and pagination fields in REST API docs

Fixes #86

## Test plan
- [x] `pytest tests/test_api_limits.py tests/test_readiness_and_api.py`
- [ ] Manual: POST `/scan-all-tools` with large tool set returns `truncated: true` and pagination hint