### PR TITLE
fix(scripts): CI gate exit codes for import_scanner_eval (#78)

### DIFF
--- a/scripts/import_scanner_eval.py
+++ b/scripts/import_scanner_eval.py
@@ -21,7 +21,23 @@ def main() -> int:
         help="Path to mcp-scanner evals/behavioral-analysis/data",
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when any scanned file is missed (for CI gates)",
+    )
+    parser.add_argument(
+        "--min-recall",
+        type=float,
+        default=None,
+        metavar="RATIO",
+        help="Exit 1 when recall is below this ratio (0.0–1.0, for CI gates)",
+    )
     args = parser.parse_args()
+
+    if args.min_recall is not None and not 0.0 <= args.min_recall <= 1.0:
+        print("--min-recall must be between 0.0 and 1.0", file=sys.stderr)
+        return 2
 
     if not args.data_dir.is_dir():
         print(f"Data directory not found: {args.data_dir}", file=sys.stderr)
@@ -54,6 +70,7 @@ def main() -> int:
 
     scanned = [row for row in rows if row.get("status") in {"detected", "missed"}]
     detected_count = sum(1 for row in scanned if row["status"] == "detected")
+    missed_count = sum(1 for row in scanned if row["status"] == "missed")
     recall = (detected_count / len(scanned)) if scanned else 1.0
 
     if args.json:
@@ -63,6 +80,7 @@ def main() -> int:
                     "total_files": len(rows),
                     "scanned": len(scanned),
                     "detected": detected_count,
+                    "missed": missed_count,
                     "recall": round(recall, 4),
                     "results": rows,
                 },
@@ -77,6 +95,10 @@ def main() -> int:
             elif row.get("status") == "skipped":
                 print(f"  SKIP {row['file']} ({row['reason']})")
 
+    if args.strict and missed_count > 0:
+        return 1
+    if args.min_recall is not None and recall < args.min_recall:
+        return 1
     return 0
 
 

--- a/tests/test_import_scanner_eval.py
+++ b/tests/test_import_scanner_eval.py
@@ -1,0 +1,77 @@
+"""Tests for scripts/import_scanner_eval.py exit codes."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_MALICIOUS = '''
+from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("test")
+
+@mcp.tool()
+def run_shell(command: str) -> str:
+    """Execute a shell command."""
+    import subprocess
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+'''
+
+_BENIGN = '''
+from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("test")
+
+@mcp.tool()
+def greet(name: str) -> str:
+    """Say hello."""
+    return f"hello {name}"
+'''
+
+
+def _write_corpus(tmp_path: Path) -> Path:
+    (tmp_path / "malicious.py").write_text(_MALICIOUS, encoding="utf-8")
+    (tmp_path / "benign.py").write_text(_BENIGN, encoding="utf-8")
+    return tmp_path
+
+
+def _run_eval(data_dir: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "scripts/import_scanner_eval.py", str(data_dir), *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_REPO_ROOT,
+    )
+
+
+def test_import_scanner_eval_default_exits_zero_on_partial_recall(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path)
+    result = _run_eval(corpus)
+    assert result.returncode == 0
+    assert "MISS benign.py" in result.stdout
+
+
+def test_import_scanner_eval_strict_exits_one_on_miss(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path)
+    result = _run_eval(corpus, "--strict")
+    assert result.returncode == 1
+    assert "MISS benign.py" in result.stdout
+
+
+def test_import_scanner_eval_min_recall_exits_one_when_below_threshold(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path)
+    result = _run_eval(corpus, "--min-recall", "1.0")
+    assert result.returncode == 1
+
+
+def test_import_scanner_eval_min_recall_passes_when_met(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path)
+    result = _run_eval(corpus, "--min-recall", "0.5")
+    assert result.returncode == 0
+
+
+def test_import_scanner_eval_missing_dir_exits_two(tmp_path: Path) -> None:
+    result = _run_eval(tmp_path / "missing")
+    assert result.returncode == 2

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -66,3 +66,18 @@ def test_scanner_eval_recall_when_corpus_available() -> None:
         assert "100.0%" in result.stdout or "141/141" in result.stdout
     else:
         assert "1/2" in result.stdout
+
+
+def test_scanner_eval_strict_exits_one_when_corpus_has_misses() -> None:
+    corpus = _behavioral_eval_corpus()
+    if corpus is None or corpus != _DEFAULT_CORPUS:
+        return
+
+    result = subprocess.run(
+        [sys.executable, "scripts/import_scanner_eval.py", str(corpus), "--strict"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_REPO_ROOT,
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- Add `--strict` and `--min-recall` to `scripts/import_scanner_eval.py` so CI can fail on detection misses
- Preserve default exit 0 for backward compatibility
- Add dedicated tests and extend semantic eval test coverage

Fixes #78

## Test plan
- [x] `uv run pytest tests/test_import_scanner_eval.py tests/test_semantic.py`
- [ ] CI green on PR
