### PR TITLE
fix(action): single scan and upload SARIF artifact (#70, #76)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/action/README.md
+++ b/action/README.md
@@ -43,13 +43,12 @@ jobs:
 ## What the action does
 
 1. Installs MCTS with `uv sync --frozen` from the pinned action ref (reproducible lockfile; default extras: `mcp`, `sast`)
-2. Runs `mcts scan` on your target
-3. Writes `mcts-report.json` and `mcts-report.sarif`
-4. Generates `mcts-report.html` via `mcts report`
-5. Uploads JSON and HTML as workflow artifacts
-6. Fails the workflow if `fail-on-critical` or `min-score` thresholds are not met
+2. Runs `mcts scan` once on your target (JSON, SARIF, and HTML are derived from the same scan)
+3. Writes `mcts-report.json`, `mcts-report.sarif`, and `mcts-report.html` to the workflow workspace
+4. Uploads JSON, HTML, and SARIF as workflow artifacts
+5. Fails the workflow if `fail-on-critical` or `min-score` thresholds are not met
 
-You upload SARIF separately (step 2 above) to show findings in GitHub's Security tab.
+Upload SARIF to GitHub Code Scanning separately (see quick start) to show findings in the Security tab.
 
 ### Installed capabilities (default extras)
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -59,9 +59,11 @@ runs:
       working-directory: ${{ github.action_path }}/..
       run: |
         set -euo pipefail
+        REPO_ROOT="${{ github.action_path }}/.."
         TARGET="${{ inputs.target }}"
         JSON_OUT="${{ github.workspace }}/mcts-report.json"
         SARIF_OUT="${{ github.workspace }}/mcts-report.sarif"
+        HTML_OUT="${{ github.workspace }}/mcts-report.html"
         ARGS=(scan "$TARGET" --no-progress -o "$JSON_OUT")
 
         if [ "${{ inputs.fail-on-critical }}" = "true" ]; then
@@ -72,12 +74,8 @@ runs:
         fi
 
         uv run mcts "${ARGS[@]}"
-        uv run mcts scan "$TARGET" --no-progress --format sarif -o "$SARIF_OUT"
-
-    - name: Generate HTML dashboard
-      shell: bash
-      working-directory: ${{ github.action_path }}/..
-      run: uv run mcts report "${{ github.workspace }}/mcts-report.json" -o "${{ github.workspace }}/mcts-report.html"
+        cp "$REPO_ROOT/mcts_analysis/scan-report.sarif" "$SARIF_OUT"
+        cp "$REPO_ROOT/mcts_analysis/scan-report.html" "$HTML_OUT"
 
     - name: Upload JSON report
       if: always()
@@ -92,3 +90,10 @@ runs:
       with:
         name: mcts-report-html
         path: mcts-report.html
+
+    - name: Upload SARIF report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: mcts-report-sarif
+        path: mcts-report.sarif


### PR DESCRIPTION
## Summary
- Run `mcts scan` once in the GitHub Action; copy SARIF/HTML from `mcts_analysis/`
- Upload SARIF as a workflow artifact alongside JSON and HTML
- Update action README

Fixes #70
Fixes #76

## Test plan
- [x] `action-validate.yml` smoke (local reasoning)
- [ ] CI Validate Action workflow on PR