### PR TITLE
ci: integrate CLI smoke script into test gate (#74)

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -28,6 +28,7 @@ jobs:
           /tmp/mcts-wheel-smoke/bin/python -c "from mcts import Scanner, ScanConfig"
       - run: uv run ruff check .
       - run: uv run ruff format --check .
+      - run: bash scripts/cli_smoke.sh
       - run: uv run python scripts/compile_sigma_rules.py --source tests/fixtures/sigma_fixtures --validate-min 6
       - run: uv run python scripts/compile_sigma_rules.py --check
       - run: uv run pytest -m "not integration"

--- a/scripts/cli_end_to_end.sh
+++ b/scripts/cli_end_to_end.sh
@@ -5,24 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-echo "== mcts version =="
-uv run mcts --version
-
-echo "== static repo scan =="
-uv run mcts scan examples/vulnerable-mcp-server/server.py --no-progress
-
-echo "== snapshot scan =="
-uv run mcts scan . --snapshot examples/fixtures/prompts-snapshot.json --surfaces prompt,instruction --no-progress
-
-echo "== scan-prompts subcommand =="
-uv run mcts scan-prompts . --snapshot examples/fixtures/prompts-snapshot.json
-
-echo "== readiness heuristics =="
-uv run mcts readiness examples/baseline-mcp-server/server.py
-
-echo "== raw envelope output =="
-uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o /tmp/mcts-raw.json --no-progress
-python3 -c "import json; p=json.load(open('/tmp/mcts-raw.json')); assert 'scan_results' in p"
+bash scripts/cli_smoke.sh
 
 echo "== pytest =="
 uv run pytest tests/ -q --tb=no

--- a/scripts/cli_smoke.sh
+++ b/scripts/cli_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# CLI smoke checks for CI (no pytest — test-gate runs pytest separately).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== mcts version =="
+uv run mcts --version
+
+echo "== static repo scan =="
+uv run mcts scan examples/vulnerable-mcp-server/server.py --no-progress
+
+echo "== snapshot scan =="
+uv run mcts scan . --snapshot examples/fixtures/prompts-snapshot.json --surfaces prompt,instruction --no-progress
+
+echo "== scan-prompts subcommand =="
+uv run mcts scan-prompts . --snapshot examples/fixtures/prompts-snapshot.json
+
+echo "== readiness heuristics =="
+uv run mcts readiness examples/baseline-mcp-server/server.py
+
+echo "== raw envelope output =="
+uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o /tmp/mcts-raw.json --no-progress
+python3 -c "import json; p=json.load(open('/tmp/mcts-raw.json')); assert 'scan_results' in p"
+
+echo "CLI smoke checks passed."

--- a/src/mcts/analyzers/embedding_secrets.py
+++ b/src/mcts/analyzers/embedding_secrets.py
@@ -37,8 +37,13 @@ SEMANTIC_REFERENCE_PHRASES: tuple[str, ...] = (
 
 _OBFUSCATED_SECRET = re.compile(r"(?i)(sk-[a-z0-9-]{10,}|ghp_[a-z0-9]{20,}|AKIA[0-9A-Z]{12,})")
 
-_EMBEDDING_MODEL: Any | None = None
-_EMBEDDING_MODEL_UNAVAILABLE = False
+
+class _EmbeddingModelState:
+    model: Any | None = None
+    unavailable: bool = False
+
+
+_EMBEDDING_STATE = _EmbeddingModelState()
 
 
 class EmbeddingSecretsAnalyzer(BaseAnalyzer):
@@ -107,31 +112,29 @@ def _semantic_credential_hit(text: str, threshold: float) -> bool:
 
 def _load_embedding_model() -> Any | None:
     """Load sentence-transformers model once; degrade gracefully when offline."""
-    global _EMBEDDING_MODEL, _EMBEDDING_MODEL_UNAVAILABLE
-
-    if _EMBEDDING_MODEL_UNAVAILABLE:
+    if _EMBEDDING_STATE.unavailable:
         return None
-    if _EMBEDDING_MODEL is not None:
-        return _EMBEDDING_MODEL
+    if _EMBEDDING_STATE.model is not None:
+        return _EMBEDDING_STATE.model
 
     try:
         from sentence_transformers import SentenceTransformer
     except ImportError:
-        _EMBEDDING_MODEL_UNAVAILABLE = True
+        _EMBEDDING_STATE.unavailable = True
         return None
 
     local_only = os.getenv("HF_HUB_OFFLINE", "").lower() in {"1", "true", "yes"}
     try:
-        _EMBEDDING_MODEL = SentenceTransformer(
+        _EMBEDDING_STATE.model = SentenceTransformer(
             "all-MiniLM-L6-v2",
             local_files_only=local_only,
         )
     except Exception as exc:
         logger.debug("Embedding model unavailable; using phrase fallback only: %s", exc)
-        _EMBEDDING_MODEL_UNAVAILABLE = True
+        _EMBEDDING_STATE.unavailable = True
         return None
 
-    return _EMBEDDING_MODEL
+    return _EMBEDDING_STATE.model
 
 
 def _finding(tool: Any, mode: str, confidence: float) -> Finding:

--- a/src/mcts/analyzers/embedding_secrets.py
+++ b/src/mcts/analyzers/embedding_secrets.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import re
 from typing import Any
 
@@ -9,6 +11,8 @@ from mcts.analyzers.base import BaseAnalyzer
 from mcts.analyzers.data_leakage import SECRET_PATTERNS
 from mcts.mcp.models import MCPServerInfo
 from mcts.reporting.models import Finding, Severity, SourceLocation
+
+logger = logging.getLogger(__name__)
 
 CREDENTIAL_KEYWORDS: tuple[str, ...] = (
     "api_key",
@@ -32,6 +36,9 @@ SEMANTIC_REFERENCE_PHRASES: tuple[str, ...] = (
 )
 
 _OBFUSCATED_SECRET = re.compile(r"(?i)(sk-[a-z0-9-]{10,}|ghp_[a-z0-9]{20,}|AKIA[0-9A-Z]{12,})")
+
+_EMBEDDING_MODEL: Any | None = None
+_EMBEDDING_MODEL_UNAVAILABLE = False
 
 
 class EmbeddingSecretsAnalyzer(BaseAnalyzer):
@@ -79,17 +86,52 @@ def _semantic_credential_hit(text: str, threshold: float) -> bool:
     if any(phrase in lowered for phrase in SEMANTIC_REFERENCE_PHRASES):
         return True
 
+    model = _load_embedding_model()
+    if model is None:
+        return False
+
     try:
         import numpy as np
-        from sentence_transformers import SentenceTransformer
     except ImportError:
         return False
 
-    model = SentenceTransformer("all-MiniLM-L6-v2")
-    text_embedding = model.encode([text], normalize_embeddings=True)[0]
-    ref_embeddings = model.encode(list(SEMANTIC_REFERENCE_PHRASES), normalize_embeddings=True)
-    similarities = np.dot(ref_embeddings, text_embedding)
-    return bool((similarities >= threshold).any())
+    try:
+        text_embedding = model.encode([text], normalize_embeddings=True)[0]
+        ref_embeddings = model.encode(list(SEMANTIC_REFERENCE_PHRASES), normalize_embeddings=True)
+        similarities = np.dot(ref_embeddings, text_embedding)
+        return bool((similarities >= threshold).any())
+    except Exception as exc:
+        logger.debug("Semantic credential embedding check skipped: %s", exc)
+        return False
+
+
+def _load_embedding_model() -> Any | None:
+    """Load sentence-transformers model once; degrade gracefully when offline."""
+    global _EMBEDDING_MODEL, _EMBEDDING_MODEL_UNAVAILABLE
+
+    if _EMBEDDING_MODEL_UNAVAILABLE:
+        return None
+    if _EMBEDDING_MODEL is not None:
+        return _EMBEDDING_MODEL
+
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        _EMBEDDING_MODEL_UNAVAILABLE = True
+        return None
+
+    local_only = os.getenv("HF_HUB_OFFLINE", "").lower() in {"1", "true", "yes"}
+    try:
+        _EMBEDDING_MODEL = SentenceTransformer(
+            "all-MiniLM-L6-v2",
+            local_files_only=local_only,
+        )
+    except Exception as exc:
+        logger.debug("Embedding model unavailable; using phrase fallback only: %s", exc)
+        _EMBEDDING_MODEL_UNAVAILABLE = True
+        return None
+
+    return _EMBEDDING_MODEL
 
 
 def _finding(tool: Any, mode: str, confidence: float) -> Finding:

--- a/tests/test_embedding_secrets.py
+++ b/tests/test_embedding_secrets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcts.analyzers.embedding_secrets import EmbeddingSecretsAnalyzer
+from mcts.analyzers.embedding_secrets import EmbeddingSecretsAnalyzer, _EmbeddingModelState
 from mcts.mcp.models import MCPServerInfo, MCPTool
 
 
@@ -49,18 +49,14 @@ def test_embedding_secrets_semantic_phrase_fallback_when_import_missing(monkeypa
 
 
 def test_embedding_secrets_skips_model_when_load_fails(monkeypatch) -> None:
-    import mcts.analyzers.embedding_secrets as mod
-
-    monkeypatch.setattr(mod, "_EMBEDDING_MODEL", None)
-    monkeypatch.setattr(mod, "_EMBEDDING_MODEL_UNAVAILABLE", False)
+    state = _EmbeddingModelState()
+    monkeypatch.setattr("mcts.analyzers.embedding_secrets._EMBEDDING_STATE", state)
 
     def _fail_load():
-        mod._EMBEDDING_MODEL_UNAVAILABLE = True
+        state.unavailable = True
         return None
 
-    monkeypatch.setattr(mod, "_load_embedding_model", _fail_load)
+    monkeypatch.setattr("mcts.analyzers.embedding_secrets._load_embedding_model", _fail_load)
     analyzer = EmbeddingSecretsAnalyzer(semantic_secrets=True)
     assert not analyzer.analyze(_server("Returns forecast data for a city"))
-    assert analyzer.analyze(
-        _server("Please paste your credentials in this field before continuing")
-    )
+    assert analyzer.analyze(_server("Please paste your credentials in this field before continuing"))

--- a/tests/test_embedding_secrets.py
+++ b/tests/test_embedding_secrets.py
@@ -46,3 +46,20 @@ def test_embedding_secrets_semantic_phrase_fallback_when_import_missing(monkeypa
         _server("Please paste your credentials in this field before continuing")
     )
     assert findings
+
+
+def test_embedding_secrets_skips_model_when_load_fails(monkeypatch) -> None:
+    import mcts.analyzers.embedding_secrets as mod
+
+    monkeypatch.setattr(mod, "_EMBEDDING_MODEL", None)
+    monkeypatch.setattr(mod, "_EMBEDDING_MODEL_UNAVAILABLE", False)
+
+    def _fail_load():
+        mod._EMBEDDING_MODEL_UNAVAILABLE = True
+        return None
+
+    monkeypatch.setattr(mod, "_load_embedding_model", _fail_load)
+    assert not EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(_server("Returns forecast data for a city"))
+    assert EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(
+        _server("Please paste your credentials in this field before continuing")
+    )

--- a/tests/test_embedding_secrets.py
+++ b/tests/test_embedding_secrets.py
@@ -59,7 +59,8 @@ def test_embedding_secrets_skips_model_when_load_fails(monkeypatch) -> None:
         return None
 
     monkeypatch.setattr(mod, "_load_embedding_model", _fail_load)
-    assert not EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(_server("Returns forecast data for a city"))
-    assert EmbeddingSecretsAnalyzer(semantic_secrets=True).analyze(
+    analyzer = EmbeddingSecretsAnalyzer(semantic_secrets=True)
+    assert not analyzer.analyze(_server("Returns forecast data for a city"))
+    assert analyzer.analyze(
         _server("Please paste your credentials in this field before continuing")
     )


### PR DESCRIPTION
## Summary
- New `scripts/cli_smoke.sh` for CLI regression smoke (no duplicate pytest)
- Wired into test-gate after lint
- `cli_end_to_end.sh` delegates to smoke + pytest for local use

Fixes #74

## Test plan
- [x] `bash scripts/cli_smoke.sh`