### PR TITLE
ci: enforce coverage threshold in test gate (#75)

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -33,6 +33,7 @@ jobs:
       - run: uv run python scripts/compile_sigma_rules.py --check
       - run: uv run pytest -m "not integration"
       - run: uv run python scripts/run_behavioral_regression.py --strict --json
+      - run: uv run python scripts/run_behavioral_eval.py --json > behavioral-eval.json
       - run: uv run pytest -m integration tests/integration/
       - run: |
           uv run python - <<'PY'
@@ -60,3 +61,8 @@ jobs:
         with:
           name: mcts-regression-report
           path: regression-report.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: behavioral-eval-report
+          path: behavioral-eval.json

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -31,7 +31,7 @@ jobs:
       - run: bash scripts/cli_smoke.sh
       - run: uv run python scripts/compile_sigma_rules.py --source tests/fixtures/sigma_fixtures --validate-min 6
       - run: uv run python scripts/compile_sigma_rules.py --check
-      - run: uv run pytest -m "not integration"
+      - run: uv run pytest -m "not integration" --cov=mcts --cov-report=term
       - run: uv run python scripts/run_behavioral_regression.py --strict --json
       - run: uv run python scripts/run_behavioral_eval.py --json > behavioral-eval.json
       - run: uv run pytest -m integration tests/integration/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,5 +172,5 @@ source = ["mcts"]
 branch = true
 
 [tool.coverage.report]
-fail_under = 0
+fail_under = 70
 show_missing = true


### PR DESCRIPTION
## Summary
- `pytest --cov=mcts` in test-gate
- `fail_under = 70` (baseline ~73%)

**Merge note:** Stacked on #73 → #74.

Fixes #75

## Test plan
- [x] `uv run pytest -m "not integration" --cov=mcts` passes at 70% threshold