### PR TITLE
ci: Python 3.11–3.13 test matrix (#71)

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -8,7 +8,12 @@ permissions:
 
 jobs:
   test:
+    name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +21,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - run: uv sync --all-extras --group dev
       - run: uv build
@@ -31,7 +36,13 @@ jobs:
       - run: bash scripts/cli_smoke.sh
       - run: uv run python scripts/compile_sigma_rules.py --source tests/fixtures/sigma_fixtures --validate-min 6
       - run: uv run python scripts/compile_sigma_rules.py --check
-      - run: uv run pytest -m "not integration" --cov=mcts --cov-report=term
+      - name: Unit tests
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
+            uv run pytest -m "not integration" --cov=mcts --cov-report=term
+          else
+            uv run pytest -m "not integration"
+          fi
       - run: uv run python scripts/run_behavioral_regression.py --strict --json
       - run: uv run python scripts/run_behavioral_eval.py --json > behavioral-eval.json
       - run: uv run pytest -m integration tests/integration/
@@ -57,12 +68,12 @@ jobs:
           uv run python -c "import json; p=json.load(open('${SARIF_OUT}')); assert p.get('version') and p.get('runs'), 'invalid SARIF'"
       - run: uv run python -c "from pathlib import Path; from mcts.testing.regression_harness import write_regression_report; write_regression_report(Path('regression-report.json'))"
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.python-version == '3.12'
         with:
           name: mcts-regression-report
           path: regression-report.json
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.python-version == '3.12'
         with:
           name: behavioral-eval-report
           path: behavioral-eval.json


### PR DESCRIPTION
## Summary
- Test gate matrix: Python 3.11, 3.12, 3.13
- Coverage + artifacts on 3.12 job only
- Full CI bundle (#74, #73, #75, #81, #99)

**Merge note:** Can merge this branch alone for all CI hardening.

Fixes #71

## Test plan
- [x] Python 3.11 pytest smoke
- [x] Coverage gate on 3.12