### PR TITLE
fix: trivial P3 — gitignore, ruff scripts src, mktemp cleanup (#98, #82, #83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ security-report.html
 report.json
 *.scan.json
 
+# Scan artifacts
+*.sarif
+mcts-report.*
+regression-report.json
+inventory.json
+
 # Local analysis mirrors (not shipped)
 competitors/
 local/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ markers = [
 [tool.ruff]
 target-version = "py311"
 line-length = 110
-src = ["src", "tests"]
+src = ["src", "tests", "scripts"]
 extend-exclude = ["eval/behavioral/handlers/parity"]
 
 [tool.ruff.lint]

--- a/scripts/cli_smoke.sh
+++ b/scripts/cli_smoke.sh
@@ -21,7 +21,9 @@ echo "== readiness heuristics =="
 uv run mcts readiness examples/baseline-mcp-server/server.py
 
 echo "== raw envelope output =="
-uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o /tmp/mcts-raw.json --no-progress
-python3 -c "import json; p=json.load(open('/tmp/mcts-raw.json')); assert 'scan_results' in p"
+RAW=$(mktemp /tmp/mcts-raw-XXXXXX)
+trap 'rm -f "$RAW"' EXIT
+uv run mcts scan examples/baseline-mcp-server/server.py --format raw -o "$RAW" --no-progress
+python3 -c "import json, sys; p=json.load(open(sys.argv[1])); assert 'scan_results' in p" "$RAW"
 
 echo "CLI smoke checks passed."


### PR DESCRIPTION
## Summary
Rebased @tcconnally's #122 onto current `main` with the macOS `mktemp` fix from review.

- **#98:** Add `*.sarif`, `mcts-report.*`, `regression-report.json`, `inventory.json` to `.gitignore`
- **#82:** Add `scripts` to `[tool.ruff] src` for isort first-party
- **#83:** macOS-safe temp file in `scripts/cli_smoke.sh` (`mktemp /tmp/mcts-raw-XXXXXX` + trap cleanup)

Note: raw-output check lives in `cli_smoke.sh` since #140 split CI smoke from `cli_end_to_end.sh`.

Supersedes #122 — credit to first-time contributor @tcconnally.

Fixes #98
Fixes #82
Fixes #83

## Test plan
- [x] `bash scripts/cli_smoke.sh`
- [x] `uv run ruff check scripts/`