### PR TITLE
fix: clarify missing PyPI version vet errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcts vet pypi:` version misses** — distinguish missing packages from missing versions, suggest recent available releases on PyPI, and accept `pypi:name:version` / `pypi:name==version` specs in addition to `pypi:name@version`
+
 ## [0.1.2] - 2026-06-10
 
 ### Added

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -969,7 +969,12 @@ def inventory(
 def vet(
     package: Annotated[
         str,
-        typer.Argument(help="Package spec: pypi:name, npm:pkg, or oci:registry/repo:tag"),
+        typer.Argument(
+            help=(
+                "Package spec: pypi:name, pypi:name:version, pypi:name==version, "
+                "npm:pkg[@version], or oci:registry/repo:tag"
+            )
+        ),
     ],
     output: Annotated[
         Path | None,

--- a/src/mcts/vet/parse.py
+++ b/src/mcts/vet/parse.py
@@ -29,11 +29,20 @@ def parse_package_spec(spec: str) -> PackageSpec:
     if eco == "oci":
         return PackageSpec(ecosystem=eco, name=rest, version=_oci_tag(rest))
 
-    name, version = _split_name_version(rest)
+    name, version = _split_name_version(eco, rest)
     return PackageSpec(ecosystem=eco, name=name, version=version)
 
 
-def _split_name_version(rest: str) -> tuple[str, str | None]:
+def _split_name_version(ecosystem: str, rest: str) -> tuple[str, str | None]:
+    if ecosystem == "pypi":
+        if "==" in rest:
+            name, version = rest.split("==", 1)
+            return name, version or None
+        if ":" in rest:
+            name, version = rest.rsplit(":", 1)
+            if name and version:
+                return name, version
+
     if rest.startswith("@"):
         if rest.count("@") >= 2:
             name, version = rest.rsplit("@", 1)

--- a/src/mcts/vet/pypi.py
+++ b/src/mcts/vet/pypi.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import httpx
 
 from mcts.reporting.models import Severity
@@ -10,32 +12,113 @@ from mcts.vet.models import VetFinding, VetReport
 from mcts.vet.parse import PackageSpec
 
 
-def vet_pypi(spec: PackageSpec) -> VetReport:
-    url = f"https://pypi.org/pypi/{spec.name}/json"
-    if spec.version:
-        url = f"https://pypi.org/pypi/{spec.name}/{spec.version}/json"
-
+def _fetch_json(url: str) -> httpx.Response:
     try:
-        response = httpx.get(url, timeout=20.0, follow_redirects=True)
+        return httpx.get(url, timeout=20.0, follow_redirects=True)
     except httpx.HTTPError as exc:
         raise RuntimeError(f"PyPI request failed: {exc}") from exc
 
+
+def _version_sort_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    parts = re.findall(r"\d+|[a-zA-Z]+", version)
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _available_version_suggestions(payload: dict, requested_version: str | None) -> list[str]:
+    versions = []
+    releases = payload.get("releases")
+    if isinstance(releases, dict):
+        versions.extend(str(version) for version in releases)
+
+    latest = str((payload.get("info") or {}).get("version") or "").strip()
+    if latest:
+        versions.append(latest)
+
+    normalized_requested = str(requested_version or "").strip()
+    unique_versions = []
+    seen = set()
+    for version in versions:
+        normalized = version.strip()
+        if not normalized or normalized == normalized_requested or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique_versions.append(normalized)
+
+    unique_versions.sort(key=_version_sort_key, reverse=True)
+    return unique_versions[:3]
+
+
+def _package_not_found_report(spec: PackageSpec) -> VetReport:
+    return VetReport(
+        ecosystem="pypi",
+        package=spec.name,
+        version=spec.version,
+        verdict="not_found",
+        findings=[
+            VetFinding(
+                id="vet-not-found",
+                title="Package not found on PyPI",
+                description=f"No PyPI project matches {spec.name!r}.",
+                severity=Severity.HIGH,
+                recommendation="Verify the package name and index URL.",
+            )
+        ],
+    )
+
+
+def _version_not_found_report(spec: PackageSpec, payload: dict) -> VetReport:
+    suggestions = _available_version_suggestions(payload, spec.version)
+    latest = str((payload.get("info") or {}).get("version") or "").strip() or None
+
+    if suggestions:
+        recommendation = f"Try an available version such as {', '.join(suggestions)}."
+    elif latest:
+        recommendation = f"Try the current latest release {latest!r} instead."
+    else:
+        recommendation = "Verify the requested version against the versions published on PyPI."
+
+    evidence = {"requested_version": spec.version, "suggestions": suggestions}
+    if latest:
+        evidence["latest_version"] = latest
+
+    return VetReport(
+        ecosystem="pypi",
+        package=spec.name,
+        version=spec.version,
+        verdict="not_found",
+        findings=[
+            VetFinding(
+                id="vet-version-not-found",
+                title="Version not found on PyPI",
+                description=(
+                    f"Package {spec.name!r} exists on PyPI, but version {spec.version!r} was not found."
+                ),
+                severity=Severity.HIGH,
+                recommendation=recommendation,
+                evidence=evidence,
+            )
+        ],
+    )
+
+
+def vet_pypi(spec: PackageSpec) -> VetReport:
+    project_url = f"https://pypi.org/pypi/{spec.name}/json"
+    url = project_url
+    if spec.version:
+        url = f"https://pypi.org/pypi/{spec.name}/{spec.version}/json"
+
+    response = _fetch_json(url)
+
     if response.status_code == 404:
-        return VetReport(
-            ecosystem="pypi",
-            package=spec.name,
-            version=spec.version,
-            verdict="not_found",
-            findings=[
-                VetFinding(
-                    id="vet-not-found",
-                    title="Package not found on PyPI",
-                    description=f"No PyPI project matches {spec.name!r}.",
-                    severity=Severity.HIGH,
-                    recommendation="Verify the package name and index URL.",
-                )
-            ],
-        )
+        if spec.version:
+            project_response = _fetch_json(project_url)
+            if project_response.status_code == 200:
+                return _version_not_found_report(spec, project_response.json())
+            if project_response.status_code == 404:
+                return _package_not_found_report(spec)
+            project_response.raise_for_status()
+
+        return _package_not_found_report(spec)
 
     response.raise_for_status()
     payload = response.json()

--- a/tests/test_vet.py
+++ b/tests/test_vet.py
@@ -18,6 +18,20 @@ def test_parse_package_spec_pypi() -> None:
     assert spec.version == "2.31.0"
 
 
+def test_parse_package_spec_pypi_colon_version() -> None:
+    spec = parse_package_spec("pypi:requests:2.31.0")
+    assert spec.ecosystem == "pypi"
+    assert spec.name == "requests"
+    assert spec.version == "2.31.0"
+
+
+def test_parse_package_spec_pypi_double_equals_version() -> None:
+    spec = parse_package_spec("pypi:requests==2.31.0")
+    assert spec.ecosystem == "pypi"
+    assert spec.name == "requests"
+    assert spec.version == "2.31.0"
+
+
 def test_parse_package_spec_npm_scoped() -> None:
     spec = parse_package_spec("npm:@types/node@20.0.0")
     assert spec.ecosystem == "npm"
@@ -59,6 +73,39 @@ def test_vet_pypi_not_found() -> None:
         report = run_vet("pypi:missing-package-xyz")
     assert report.verdict == "not_found"
     assert report.findings[0].severity == Severity.HIGH
+    assert report.findings[0].title == "Package not found on PyPI"
+
+
+def test_vet_pypi_missing_version_suggests_recent_releases() -> None:
+    version_response = MagicMock(status_code=404)
+    project_payload = {
+        "info": {
+            "name": "kubernetes",
+            "version": "32.0.1",
+            "summary": "Kubernetes Python client",
+            "description": "Safe description",
+            "project_urls": {},
+        },
+        "releases": {
+            "32.0.1": [],
+            "31.0.0": [],
+            "30.1.0": [],
+            "25.0.0": [],
+        },
+    }
+    project_response = MagicMock(status_code=200, json=lambda: project_payload)
+    project_response.raise_for_status = MagicMock()
+
+    with patch("mcts.vet.pypi.httpx.get", side_effect=[version_response, project_response]):
+        report = run_vet("pypi:kubernetes==25.0.0")
+
+    assert report.verdict == "not_found"
+    assert report.findings[0].id == "vet-version-not-found"
+    assert report.findings[0].title == "Version not found on PyPI"
+    assert "25.0.0" in report.findings[0].description
+    assert report.findings[0].evidence["latest_version"] == "32.0.1"
+    assert report.findings[0].evidence["suggestions"] == ["32.0.1", "31.0.0", "30.1.0"]
+    assert "32.0.1" in report.findings[0].recommendation
 
 
 def test_vet_npm_flags_lifecycle_script() -> None:


### PR DESCRIPTION
## Summary
- distinguish missing PyPI packages from missing versions in `mcts vet pypi:`
- suggest recent available versions when a specific PyPI release is missing
- accept `pypi:name:version` and `pypi:name==version` alongside `pypi:name@version`

Fixes #223.

## Test plan
- `uv run pytest tests/test_vet.py`
- `uv run ruff check src tests`
- `HOME=$(mktemp -d /tmp/mcts-home-XXXXXX) uv run pytest`
