### PR TITLE
Fail fast on invalid governance policy files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+
 ## [0.1.2] - 2026-06-10
 
 ### Added

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -704,6 +704,12 @@ def scan(
         surface_scoped_analyzers=surface_scoped,
     )
 
+    try:
+        gov = load_policy(config_obj.governance_policy)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+
     if machine_wide:
         try:
             resolved_theme = get_theme(theme)
@@ -819,11 +825,6 @@ def scan(
     _check_strict_live(report, config_obj)
     _check_strict_discovery(report, config_obj)
     _check_gates(report, config_obj)
-    try:
-        gov = load_policy(config_obj.governance_policy)
-    except (FileNotFoundError, ValueError) as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(code=2) from exc
     if gov is not None:
         violations = evaluate_policy(
             policy=gov,

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from mcts.cli.main import app
 from mcts.governance import evaluate_policy, load_policy
+from mcts.output.analysis_dir import ANALYSIS_DIR_NAME
+
+runner = CliRunner()
 
 
 def test_load_and_evaluate_policy(tmp_path: Path) -> None:
@@ -23,3 +29,32 @@ def test_load_and_evaluate_policy(tmp_path: Path) -> None:
     )
     assert any("score" in item for item in violations)
     assert any("allowlist" in item for item in violations)
+
+
+def test_scan_missing_policy_fails_before_reports(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "server.py"
+    target.write_text("print('not an mcp server')\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app,
+        ["scan", str(target), "--policy", str(tmp_path / "missing.yaml"), "--no-progress"],
+    )
+
+    assert result.exit_code == 2
+    assert "Governance policy not found" in result.stdout
+    assert not (tmp_path / ANALYSIS_DIR_NAME).exists()
+
+
+def test_scan_invalid_policy_fails_before_reports(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "server.py"
+    target.write_text("print('not an mcp server')\n", encoding="utf-8")
+    policy = tmp_path / "policy.yaml"
+    policy.write_text("- not-a-mapping\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["scan", str(target), "--policy", str(policy), "--no-progress"])
+
+    assert result.exit_code == 2
+    assert "Governance policy must be a YAML mapping" in result.stdout
+    assert not (tmp_path / ANALYSIS_DIR_NAME).exists()


### PR DESCRIPTION
## Summary

Fixes #213.

This preloads the governance policy immediately after scan config creation, before the scanner/progress/report-writing path starts. Missing or invalid `--policy` files now return exit 2 before any scan artifacts are written, and the loaded policy object is reused for post-scan governance evaluation.

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_governance.py -q`
- [x] `uv run --frozen ruff check src tests`
- [ ] Manual CLI test (if applicable)
  ```bash
  uv run mcts scan examples/vulnerable-mcp-server/server.py
  uv run mcts scan examples/vulnerable-mcp-server/server.py -o report.json
  uv run mcts report report.json -o security-report.html
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)