### PR TITLE
fix(vet): clarify missing PyPI versions

### DIFF
--- a/src/mcts/vet/parse.py
+++ b/src/mcts/vet/parse.py
@@ -34,14 +34,24 @@ def parse_package_spec(spec: str) -> PackageSpec:
 
 
 def _split_name_version(rest: str) -> tuple[str, str | None]:
+    if "==" in rest:
+        name, version = rest.split("==", 1)
+        return name, version or None
+
     if rest.startswith("@"):
         if rest.count("@") >= 2:
             name, version = rest.rsplit("@", 1)
+            return name, version or None
+        if ":" in rest:
+            name, version = rest.rsplit(":", 1)
             return name, version or None
         return rest, None
 
     if "@" in rest:
         name, version = rest.rsplit("@", 1)
+        return name, version or None
+    if ":" in rest:
+        name, version = rest.rsplit(":", 1)
         return name, version or None
     return rest, None
 

--- a/src/mcts/vet/pypi.py
+++ b/src/mcts/vet/pypi.py
@@ -10,32 +10,119 @@ from mcts.vet.models import VetFinding, VetReport
 from mcts.vet.parse import PackageSpec
 
 
+def _pypi_get(url: str) -> httpx.Response:
+    try:
+        return httpx.get(url, timeout=20.0, follow_redirects=True)
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"PyPI request failed: {exc}") from exc
+
+
+def _release_suggestions(releases: object, latest: str | None, *, limit: int = 3) -> list[str]:
+    suggestions: list[str] = []
+
+    def add(version: object) -> None:
+        text = str(version or "").strip()
+        if text and text not in suggestions:
+            suggestions.append(text)
+
+    add(latest)
+    if isinstance(releases, dict):
+        dated_versions: list[tuple[str, str]] = []
+        undated_versions: list[str] = []
+        for version, files in releases.items():
+            newest_upload = ""
+            if isinstance(files, list):
+                newest_upload = max(
+                    (
+                        str(file.get("upload_time_iso_8601") or file.get("upload_time") or "")
+                        for file in files
+                        if isinstance(file, dict)
+                    ),
+                    default="",
+                )
+            if newest_upload:
+                dated_versions.append((newest_upload, str(version)))
+            else:
+                undated_versions.append(str(version))
+
+        for _, version in sorted(dated_versions, reverse=True):
+            add(version)
+            if len(suggestions) >= limit:
+                return suggestions
+        for version in reversed(undated_versions):
+            add(version)
+            if len(suggestions) >= limit:
+                return suggestions
+
+    return suggestions[:limit]
+
+
+def _package_not_found_report(spec: PackageSpec) -> VetReport:
+    return VetReport(
+        ecosystem="pypi",
+        package=spec.name,
+        version=spec.version,
+        verdict="not_found",
+        findings=[
+            VetFinding(
+                id="vet-not-found",
+                title="Package not found on PyPI",
+                description=f"No PyPI project matches {spec.name!r}.",
+                severity=Severity.HIGH,
+                recommendation="Verify the package name and index URL.",
+            )
+        ],
+    )
+
+
+def _version_not_found_report(spec: PackageSpec, payload: dict) -> VetReport:
+    info = payload.get("info") or {}
+    latest = str(info.get("version") or "")
+    suggestions = _release_suggestions(payload.get("releases"), latest)
+    latest_hint = f" Latest: {latest}." if latest else ""
+    latest_title_hint = f" (latest: {latest})" if latest else ""
+    recommendation = (
+        f"Try pypi:{spec.name}:{suggestions[0]} or check the available PyPI releases."
+        if suggestions
+        else "Check the available PyPI releases and choose an existing version."
+    )
+    return VetReport(
+        ecosystem="pypi",
+        package=spec.name,
+        version=spec.version,
+        verdict="version_not_found",
+        findings=[
+            VetFinding(
+                id="vet-version-not-found",
+                title=f"Version {spec.version!r} not found for {spec.name!r}{latest_title_hint}",
+                description=f"PyPI has project {spec.name!r}, but not version {spec.version!r}.{latest_hint}",
+                severity=Severity.HIGH,
+                recommendation=recommendation,
+                evidence={
+                    "requested_version": spec.version,
+                    "latest": latest,
+                    "suggestions": suggestions,
+                },
+            )
+        ],
+    )
+
+
 def vet_pypi(spec: PackageSpec) -> VetReport:
     url = f"https://pypi.org/pypi/{spec.name}/json"
     if spec.version:
         url = f"https://pypi.org/pypi/{spec.name}/{spec.version}/json"
 
-    try:
-        response = httpx.get(url, timeout=20.0, follow_redirects=True)
-    except httpx.HTTPError as exc:
-        raise RuntimeError(f"PyPI request failed: {exc}") from exc
+    response = _pypi_get(url)
 
     if response.status_code == 404:
-        return VetReport(
-            ecosystem="pypi",
-            package=spec.name,
-            version=spec.version,
-            verdict="not_found",
-            findings=[
-                VetFinding(
-                    id="vet-not-found",
-                    title="Package not found on PyPI",
-                    description=f"No PyPI project matches {spec.name!r}.",
-                    severity=Severity.HIGH,
-                    recommendation="Verify the package name and index URL.",
-                )
-            ],
-        )
+        if spec.version:
+            project_response = _pypi_get(f"https://pypi.org/pypi/{spec.name}/json")
+            if project_response.status_code == 200:
+                return _version_not_found_report(spec, project_response.json())
+            if project_response.status_code != 404:
+                project_response.raise_for_status()
+        return _package_not_found_report(spec)
 
     response.raise_for_status()
     payload = response.json()

--- a/tests/test_vet.py
+++ b/tests/test_vet.py
@@ -18,6 +18,20 @@ def test_parse_package_spec_pypi() -> None:
     assert spec.version == "2.31.0"
 
 
+def test_parse_package_spec_pypi_colon_version() -> None:
+    spec = parse_package_spec("pypi:kubernetes:25.0.0")
+    assert spec.ecosystem == "pypi"
+    assert spec.name == "kubernetes"
+    assert spec.version == "25.0.0"
+
+
+def test_parse_package_spec_pypi_equals_version() -> None:
+    spec = parse_package_spec("pypi:fastapi==0.136.3")
+    assert spec.ecosystem == "pypi"
+    assert spec.name == "fastapi"
+    assert spec.version == "0.136.3"
+
+
 def test_parse_package_spec_npm_scoped() -> None:
     spec = parse_package_spec("npm:@types/node@20.0.0")
     assert spec.ecosystem == "npm"
@@ -59,6 +73,32 @@ def test_vet_pypi_not_found() -> None:
         report = run_vet("pypi:missing-package-xyz")
     assert report.verdict == "not_found"
     assert report.findings[0].severity == Severity.HIGH
+
+
+def test_vet_pypi_version_not_found_suggests_latest() -> None:
+    version_response = MagicMock(status_code=404)
+    project_payload = {
+        "info": {"version": "32.0.1"},
+        "releases": {
+            "30.1.0": [{"upload_time_iso_8601": "2025-01-01T00:00:00Z"}],
+            "31.0.0": [{"upload_time_iso_8601": "2025-05-01T00:00:00Z"}],
+            "32.0.1": [{"upload_time_iso_8601": "2025-10-01T00:00:00Z"}],
+        },
+    }
+    project_response = MagicMock(status_code=200, json=lambda: project_payload)
+    project_response.raise_for_status = MagicMock()
+
+    with patch("mcts.vet.pypi.httpx.get", side_effect=[version_response, project_response]) as get:
+        report = run_vet("pypi:kubernetes:25.0.0")
+
+    assert report.verdict == "version_not_found"
+    assert report.package == "kubernetes"
+    assert report.version == "25.0.0"
+    assert report.findings[0].id == "vet-version-not-found"
+    assert "Latest: 32.0.1" in report.findings[0].description
+    assert report.findings[0].evidence["suggestions"] == ["32.0.1", "31.0.0", "30.1.0"]
+    assert get.call_args_list[0].args[0] == "https://pypi.org/pypi/kubernetes/25.0.0/json"
+    assert get.call_args_list[1].args[0] == "https://pypi.org/pypi/kubernetes/json"
 
 
 def test_vet_npm_flags_lifecycle_script() -> None:


### PR DESCRIPTION
## Summary
- parse PyPI specs written as `pypi:name:version` and `pypi:name==version` in addition to the existing `@` form
- distinguish missing PyPI projects from missing PyPI versions
- fetch project metadata on version 404s so the report can include latest-version suggestions

Fixes #223.

## Verification
- `.venv-codex/bin/python -m pytest tests/test_vet.py -q`
- `.venv-codex/bin/python -m ruff check src/mcts/vet/parse.py src/mcts/vet/pypi.py tests/test_vet.py`
- `.venv-codex/bin/python -m ruff format --check src/mcts/vet/parse.py src/mcts/vet/pypi.py tests/test_vet.py`
- `.venv-codex/bin/python -m mcts.cli.main vet --json pypi:kubernetes:25.0.0; test $? -eq 1`
- `git diff --check`

I removed the temporary `.venv-codex` before committing.