### PR TITLE
feat(fuzz): add remote protocol fuzz via --url for HTTP/SSE endpoints

### DIFF
--- a/docs/scanning/fuzzing.md
+++ b/docs/scanning/fuzzing.md
@@ -86,17 +86,64 @@ mcts fuzz . --config ~/.cursor/mcp.json --server my-server \
   --fuzz-level safe --i-understand-live-risk -o fuzz.json
 ```
 
+### Remote fuzz (HTTP/SSE)
+
+Fuzz a remote MCP endpoint over HTTP or SSE instead of spawning a local subprocess:
+
+```bash
+# Streamable HTTP (default transport)
+mcts fuzz --url https://mcp.example.com/mcp \
+  --fuzz-level safe \
+  --i-understand-live-risk
+
+# With Bearer token authentication
+mcts fuzz --url https://mcp.example.com/mcp \
+  --bearer-token "$MCP_TOKEN" \
+  --fuzz-level standard \
+  --i-understand-live-risk
+
+# SSE transport
+mcts fuzz --url https://mcp.example.com/sse \
+  --transport sse \
+  --i-understand-live-risk
+
+# Custom headers
+mcts fuzz --url https://mcp.example.com/mcp \
+  --header "X-API-Key: secret" \
+  --header "X-Tenant: acme" \
+  --i-understand-live-risk -o fuzz.json
+```
+
+`--url` is mutually exclusive with `--command` and `--config`. When `--url` is
+provided, MCTS sends raw JSON-RPC POST requests to the endpoint using `httpx`
+and classifies the responses with the same rules as stdio fuzz.
+
 ---
 
 ## Consent
 
 | Flag / env | Required for |
 |------------|--------------|
-| `--i-understand-live-risk` | Starting any fuzz session (subprocess) |
+| `--i-understand-live-risk` | Starting any fuzz session (stdio subprocess **or** remote HTTP/SSE) |
 | `MCTS_LIVE_OK=1` | CI bypass for live consent |
 | `--i-understand-fuzz-risk` | **aggressive** level only |
 
 Without live consent, exit code **2**. Without fuzz-risk consent on aggressive, exit code **2**.
+
+### Remote probing consent
+
+Remote fuzzing (`--url`) carries the same consent requirement as local stdio
+fuzzing. Sending fuzz probes to a remote MCP server can trigger unexpected
+behavior, consume resources, or expose security weaknesses. **Always** obtain
+authorization from the server operator before running remote fuzz.
+
+- Never fuzz production endpoints without explicit approval.
+- Use `--fuzz-level safe` (default) for initial assessments — it never invokes
+  `tools/call`.
+- Bearer tokens and custom headers supplied via `--bearer-token` / `--header`
+  are sent with every probe request. Treat them like credentials — do not log
+  them or commit them to source control.
+- Set `MCTS_LIVE_OK=1` in CI to bypass the interactive consent gate.
 
 ---
 
@@ -196,13 +243,27 @@ Use **safe** level on trusted fixture servers only:
 
 Never run **aggressive** fuzz against production or third-party servers.
 
+### Remote fuzz CI example
+
+```yaml
+- name: Remote protocol fuzz (safe)
+  env:
+    MCTS_LIVE_OK: "1"
+    MCP_TOKEN: ${{ secrets.MCP_BEARER_TOKEN }}
+  run: |
+    mcts fuzz --url https://staging-mcp.example.com/mcp \
+      --bearer-token "$MCP_TOKEN" \
+      --fuzz-level safe --i-understand-live-risk -o fuzz.json
+    mcts scan . --runtime-events fuzz.json --no-progress -o report.json
+```
+
 ---
 
 ## Planned fuzz capabilities
 
 | Capability | Status | GAP | Notes |
 |------------|--------|-----|-------|
-| Remote protocol fuzz (`mcts fuzz --url`) | Planned | GAP-190 | HTTP/SSE targets |
+| Remote protocol fuzz (`mcts fuzz --url`) | **Shipped** | GAP-190 | HTTP/SSE via `--url`, `--transport`, `--bearer-token` |
 | WebSocket MCP transport fuzz | Missing | GAP-187 | WebSocket transport coverage |
 | Docker MCP server auto-detection | Missing | GAP-188 | Container-launched servers |
 | Deeper aggressive corpus | Partial | GAP-186 | Expanded dynamic analyzer corpus |

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -1106,9 +1106,9 @@ def fuzz(
     target: Annotated[
         Path,
         typer.Argument(
-            help="Path to MCP server entrypoint (use . with --config)",
+            help="Path to MCP server entrypoint (use . with --config or --url)",
         ),
-    ],
+    ] = Path("."),
     fuzz_level: Annotated[
         str,
         typer.Option(
@@ -1133,6 +1133,22 @@ def fuzz(
         str | None,
         typer.Option("--server", help="Server name inside --config mcpServers"),
     ] = None,
+    url: Annotated[
+        str | None,
+        typer.Option("--url", help="Remote MCP server URL (SSE or streamable HTTP)"),
+    ] = None,
+    transport: Annotated[
+        str,
+        typer.Option("--transport", help="Remote transport: streamable-http or sse"),
+    ] = "streamable-http",
+    bearer_token: Annotated[
+        str | None,
+        typer.Option("--bearer-token", help="Bearer token for remote MCP server"),
+    ] = None,
+    header: Annotated[
+        list[str] | None,
+        typer.Option("--header", help="Custom HTTP header (Name: Value). Repeatable."),
+    ] = None,
     output: Annotated[
         Path | None,
         typer.Option("--output", "-o", help="Write fuzz findings JSON"),
@@ -1141,7 +1157,7 @@ def fuzz(
         bool,
         typer.Option(
             "--i-understand-live-risk",
-            help="Consent to start a live MCP server subprocess",
+            help="Consent to probe a live MCP server (subprocess or remote)",
         ),
     ] = False,
     understand_fuzz_risk: Annotated[
@@ -1156,7 +1172,7 @@ def fuzz(
         typer.Option("--theme", help="Terminal theme: cyber, minimal, github"),
     ] = ThemeName.CYBER.value,
 ) -> None:
-    """Run safe read-only MCP protocol fuzz probes against a stdio server."""
+    """Run safe read-only MCP protocol fuzz probes against a stdio or remote server."""
     import json
 
     from mcts.analyzers.runtime_events import events_from_fuzz_findings
@@ -1166,14 +1182,30 @@ def fuzz(
     from mcts.probe.startup_errors import MCPStartupError
     from mcts.taxonomy.mapper import enrich_findings
 
-    if target == Path(".") and config is None:
+    is_remote = bool(url)
+
+    if url and command:
+        console.print("[red]Error:[/red] --url and --command are mutually exclusive.")
+        raise typer.Exit(code=2)
+
+    if url and config:
+        console.print("[red]Error:[/red] --url and --config are mutually exclusive.")
+        raise typer.Exit(code=2)
+
+    if not is_remote and target == Path(".") and config is None:
         _print_discovery_hints(target)
 
     if not live_consent_granted(flag=understand_live_risk):
-        console.print(
-            "[red]Fuzzing requires live server consent.[/red] Pass --i-understand-live-risk "
-            "or set MCTS_LIVE_OK=1 in CI."
-        )
+        if is_remote:
+            console.print(
+                "[red]Remote fuzzing sends test probes to a live MCP endpoint.[/red] "
+                "Pass --i-understand-live-risk or set MCTS_LIVE_OK=1 in CI."
+            )
+        else:
+            console.print(
+                "[red]Fuzzing requires live server consent.[/red] Pass --i-understand-live-risk "
+                "or set MCTS_LIVE_OK=1 in CI."
+            )
         raise typer.Exit(code=2)
 
     if config and not server:
@@ -1194,6 +1226,7 @@ def fuzz(
 
     scan_target = config if (config and target == Path(".")) else target
     live_args = [part.strip() for part in args.split(",") if part.strip()] if args else []
+    remote_headers = _parse_headers(header)
 
     try:
         resolved_theme = get_theme(theme)
@@ -1211,6 +1244,10 @@ def fuzz(
         fuzz_level=level,
         fuzz_consent=understand_fuzz_risk,
         theme=resolved_theme.name.value,
+        remote_url=url,
+        remote_transport=transport,
+        bearer_token=bearer_token,
+        remote_headers=remote_headers,
     )
 
     try:
@@ -1227,6 +1264,7 @@ def fuzz(
 
     findings = enrich_findings(result.findings)
     runtime_event_rows = events_from_fuzz_findings(findings)
+    target_label = url or str(scan_target)
     console.print(f"[bold]MCTS fuzz[/bold] — level={result.level.value}, probes={result.probes_run}")
     if not findings:
         console.print("[green]No fuzz findings — server handled probes cleanly.[/green]")
@@ -1235,7 +1273,7 @@ def fuzz(
             console.print(f"  [{finding.severity.value}] {finding.title}")
 
     payload = {
-        "target": str(scan_target),
+        "target": target_label,
         "fuzz_level": result.level.value,
         "probes_run": result.probes_run,
         "runtime_events": runtime_event_rows,

--- a/src/mcts/fuzz/__init__.py
+++ b/src/mcts/fuzz/__init__.py
@@ -2,5 +2,13 @@
 
 from mcts.fuzz.payloads import FuzzLevel, FuzzProbe, probes_for_level
 from mcts.fuzz.runner import FuzzResult, FuzzRunner
+from mcts.fuzz.transport_http import run_probe_messages_http
 
-__all__ = ["FuzzLevel", "FuzzProbe", "FuzzResult", "FuzzRunner", "probes_for_level"]
+__all__ = [
+    "FuzzLevel",
+    "FuzzProbe",
+    "FuzzResult",
+    "FuzzRunner",
+    "probes_for_level",
+    "run_probe_messages_http",
+]

--- a/src/mcts/fuzz/runner.py
+++ b/src/mcts/fuzz/runner.py
@@ -10,7 +10,11 @@ from mcts.discovery.live_config import resolve_live_config
 from mcts.fuzz.classifier import classify_response, finding_from_classification
 from mcts.fuzz.payloads import FuzzLevel, probes_for_level
 from mcts.fuzz.transport import run_probe_messages
+from mcts.fuzz.transport_http import run_probe_messages_http
+from mcts.probe.auth import RemoteAuth
 from mcts.probe.consent import require_live_consent
+from mcts.probe.http_session import probe_remote, remote_config_from_scan
+from mcts.probe.models import RemoteServerConfig
 from mcts.probe.session import MCPProbeError, probe_stdio
 from mcts.probe.startup_errors import MCPStartupError
 from mcts.reporting.models import Finding
@@ -24,17 +28,21 @@ class FuzzResult:
 
 
 class FuzzRunner:
-    """Run safe read-only MCP protocol fuzz probes against a stdio server."""
+    """Run safe read-only MCP protocol fuzz probes against a stdio or remote server."""
 
     def __init__(self, config: ScanConfig) -> None:
         self.config = config
+        self._remote_cfg: RemoteServerConfig | None = None
+
+    @property
+    def _is_remote(self) -> bool:
+        return bool(self.config.remote_url)
 
     def run(self) -> FuzzResult:
         return asyncio.run(self.run_async())
 
     async def run_async(self) -> FuzzResult:
         require_live_consent(flag=self.config.live_consent)
-        live_config = resolve_live_config(self.config)
         level = FuzzLevel(self.config.fuzz_level)
 
         if level == FuzzLevel.AGGRESSIVE and not self.config.fuzz_consent:
@@ -42,26 +50,14 @@ class FuzzRunner:
                 "Aggressive fuzz may invoke tools/call. Pass --i-understand-fuzz-risk to proceed."
             )
 
-        try:
-            server = await probe_stdio(live_config, timeout_seconds=min(self.config.timeout_seconds, 30))
-            tool_names = tuple(tool.name for tool in server.tools)
-        except MCPStartupError:
-            raise
-        except MCPProbeError:
-            raise
-
+        tool_names = await self._discover_tools()
         probes = probes_for_level(level, tool_names)
         findings: list[Finding] = []
         seen: set[str] = set()
 
         for probe in probes:
-            response_text, process_exited = await run_probe_messages(
-                live_config,
-                probe.messages,
-                timeout_seconds=min(self.config.timeout_seconds, 15),
-                followups=probe.followups,
-            )
-            classified = classify_response(probe, response_text, process_exited=process_exited)
+            response_text, errored = await self._send_probe(probe.messages, probe.followups)
+            classified = classify_response(probe, response_text, process_exited=errored)
             if classified is None:
                 continue
             finding = finding_from_classification(probe, classified)
@@ -69,6 +65,73 @@ class FuzzRunner:
                 continue
             seen.add(finding.id)
             finding.evidence["response_excerpt"] = response_text[:500]
+            if self._is_remote:
+                finding.evidence["transport"] = "http"
+                finding.evidence["remote_url"] = self.config.remote_url
             findings.append(finding)
 
         return FuzzResult(findings=findings, probes_run=len(probes), level=level)
+
+    async def _discover_tools(self) -> tuple[str, ...]:
+        """Discover tool names via the appropriate transport."""
+        if self._is_remote:
+            server = await probe_remote(
+                self._get_remote_config(),
+                timeout_seconds=min(self.config.timeout_seconds, 30),
+            )
+            return tuple(tool.name for tool in server.tools)
+
+        live_config = resolve_live_config(self.config)
+        try:
+            server = await probe_stdio(
+                live_config,
+                timeout_seconds=min(self.config.timeout_seconds, 30),
+            )
+            return tuple(tool.name for tool in server.tools)
+        except MCPStartupError:
+            raise
+        except MCPProbeError:
+            raise
+
+    async def _send_probe(
+        self,
+        messages: tuple,
+        followups: tuple,
+    ) -> tuple[str, bool]:
+        """Send a single fuzz probe via the appropriate transport."""
+        timeout = min(self.config.timeout_seconds, 15)
+        if self._is_remote:
+            return await run_probe_messages_http(
+                self._get_remote_config(),
+                messages,
+                timeout_seconds=timeout,
+                followups=followups,
+            )
+        live_config = resolve_live_config(self.config)
+        return await run_probe_messages(
+            live_config,
+            messages,
+            timeout_seconds=timeout,
+            followups=followups,
+        )
+
+    def _get_remote_config(self) -> RemoteServerConfig:
+        if self._remote_cfg is None:
+            self._remote_cfg = self._build_remote_config()
+        return self._remote_cfg
+
+    def _build_remote_config(self) -> RemoteServerConfig:
+        auth = RemoteAuth(
+            bearer_token=self.config.bearer_token,
+            headers=self.config.remote_headers,
+            oauth_token_url=self.config.oauth_token_url,
+            oauth_client_id=self.config.oauth_client_id,
+            oauth_client_secret=self.config.oauth_client_secret,
+            oauth_scopes=self.config.oauth_scopes,
+        )
+        return remote_config_from_scan(
+            url=self.config.remote_url or "",
+            transport=self.config.remote_transport,
+            auth=auth,
+            server_name=self.config.config_server or "remote-server",
+        )

--- a/src/mcts/fuzz/transport_http.py
+++ b/src/mcts/fuzz/transport_http.py
@@ -1,0 +1,102 @@
+"""Raw HTTP JSON-RPC transport for fuzz probes against remote MCP endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+
+from mcts.probe.models import RemoteServerConfig
+
+logger = logging.getLogger(__name__)
+
+_JSONRPC_CONTENT_TYPE = {"Content-Type": "application/json"}
+
+
+async def run_probe_messages_http(
+    config: RemoteServerConfig,
+    messages: tuple[Any, ...],
+    *,
+    timeout_seconds: float = 10.0,
+    followups: tuple[dict[str, Any], ...] = (),
+) -> tuple[str, bool]:
+    """POST JSON-RPC payloads to a remote MCP HTTP endpoint and collect responses.
+
+    Returns ``(response_text, server_error)`` matching the stdio transport
+    signature so the classifier can be reused without changes.
+    ``server_error`` is True when the server returned a 5xx status or the
+    connection failed entirely (analogous to ``process_exited`` in stdio).
+    """
+    auth_headers = config.auth.resolve_headers() if config.auth else {}
+    headers = {**_JSONRPC_CONTENT_TYPE, **auth_headers}
+
+    chunks: list[str] = []
+    server_error = False
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_seconds, connect=min(timeout_seconds, 10.0)),
+            follow_redirects=True,
+        ) as client:
+            for message in messages:
+                body = _encode_body(message)
+                text, is_error = await _post_once(client, config.url, body, headers)
+                if text:
+                    chunks.append(text)
+                if is_error:
+                    server_error = True
+
+            if (
+                followups
+                and messages
+                and isinstance(messages[0], dict)
+                and messages[0].get("method") == "initialize"
+            ):
+                initialized = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+                await _post_once(
+                    client,
+                    config.url,
+                    json.dumps(initialized),
+                    headers,
+                )
+
+            for followup in followups:
+                body = json.dumps(followup)
+                text, is_error = await _post_once(client, config.url, body, headers)
+                if text:
+                    chunks.append(text)
+                if is_error:
+                    server_error = True
+
+    except httpx.ConnectError:
+        chunks.append("")
+        server_error = True
+    except TimeoutError:
+        chunks.append("")
+
+    return "\n".join(chunks), server_error
+
+
+async def _post_once(
+    client: httpx.AsyncClient,
+    url: str,
+    body: str,
+    headers: dict[str, str],
+) -> tuple[str, bool]:
+    """Send a single POST and return ``(response_text, is_server_error)``."""
+    try:
+        resp = await client.post(url, content=body, headers=headers)
+        is_error = resp.status_code >= 500
+        return resp.text, is_error
+    except httpx.TimeoutException:
+        return "", False
+    except httpx.HTTPError as exc:
+        return str(exc), True
+
+
+def _encode_body(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    return json.dumps(message)

--- a/tests/test_fuzz_remote.py
+++ b/tests/test_fuzz_remote.py
@@ -1,0 +1,340 @@
+"""Tests for remote HTTP/SSE fuzz transport and runner integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from mcts.core.config import ScanConfig
+from mcts.fuzz.runner import FuzzRunner
+from mcts.fuzz.transport_http import run_probe_messages_http
+from mcts.mcp.models import MCPServerInfo, MCPTool
+from mcts.probe.models import RemoteServerConfig
+from mcts.reporting.models import Severity
+
+
+def _remote_config(url: str = "https://mcp.example.com/mcp") -> RemoteServerConfig:
+    return RemoteServerConfig(url=url, transport="streamable-http")
+
+
+def _scan_config(**overrides: Any) -> ScanConfig:
+    defaults: dict[str, Any] = {
+        "target": Path("."),
+        "live_consent": True,
+        "fuzz_level": "safe",
+        "remote_url": "https://mcp.example.com/mcp",
+        "remote_transport": "streamable-http",
+    }
+    defaults.update(overrides)
+    return ScanConfig(**defaults)
+
+
+def _fake_server(tool_names: tuple[str, ...] = ("read_file",)) -> MCPServerInfo:
+    return MCPServerInfo(
+        name="remote-test",
+        tools=[MCPTool(name=n) for n in tool_names],
+        transport="streamable-http-live",
+        discovery_mode="live",
+        initialize_succeeded=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# transport_http unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_transport_posts_jsonrpc() -> None:
+    """Verify run_probe_messages_http sends JSON-RPC messages via POST."""
+    response = httpx.Response(
+        200,
+        json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "Not found"}},
+    )
+    transport = httpx.MockTransport(lambda req: response)
+
+    cfg = _remote_config("https://mcp.test/mcp")
+    async with httpx.AsyncClient(transport=transport) as _:
+        with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=ctx)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            ctx.post = AsyncMock(return_value=response)
+            mock_cls.return_value = ctx
+
+            text, server_error = await run_probe_messages_http(
+                cfg,
+                ({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},),
+                timeout_seconds=5.0,
+            )
+
+    assert "Not found" in text
+    assert server_error is False
+
+
+@pytest.mark.asyncio
+async def test_http_transport_flags_server_error() -> None:
+    """A 500 response should set server_error=True."""
+    response = httpx.Response(500, text="Internal Server Error")
+    cfg = _remote_config()
+
+    with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=ctx)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.post = AsyncMock(return_value=response)
+        mock_cls.return_value = ctx
+
+        text, server_error = await run_probe_messages_http(
+            cfg,
+            ({"jsonrpc": "2.0", "id": 1, "params": {}},),
+            timeout_seconds=5.0,
+        )
+
+    assert server_error is True
+    assert "Internal Server Error" in text
+
+
+@pytest.mark.asyncio
+async def test_http_transport_handles_connect_error() -> None:
+    """Connection failure should return empty text with server_error=True."""
+    cfg = _remote_config()
+
+    with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=ctx)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_cls.return_value = ctx
+
+        text, server_error = await run_probe_messages_http(
+            cfg,
+            ({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},),
+        )
+
+    assert server_error is True
+
+
+@pytest.mark.asyncio
+async def test_http_transport_sends_malformed_json_as_string() -> None:
+    """Malformed JSON (a raw string probe) should be sent as-is."""
+    response = httpx.Response(400, text="Bad Request")
+    cfg = _remote_config()
+
+    with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=ctx)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.post = AsyncMock(return_value=response)
+        mock_cls.return_value = ctx
+
+        text, _ = await run_probe_messages_http(
+            cfg,
+            ("{ not valid json",),
+            timeout_seconds=5.0,
+        )
+
+    posted_body = ctx.post.call_args[1].get("content") or ctx.post.call_args[0][1]
+    assert "not valid json" in str(posted_body)
+
+
+@pytest.mark.asyncio
+async def test_http_transport_sends_auth_headers() -> None:
+    """Bearer token from RemoteServerConfig should appear in POST headers."""
+    from mcts.probe.auth import RemoteAuth
+
+    response = httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": {}})
+    auth = RemoteAuth(bearer_token="test-token-xyz")
+    cfg = RemoteServerConfig(
+        url="https://mcp.test/mcp",
+        transport="streamable-http",
+        auth=auth,
+    )
+
+    with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=ctx)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.post = AsyncMock(return_value=response)
+        mock_cls.return_value = ctx
+
+        await run_probe_messages_http(
+            cfg,
+            ({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},),
+        )
+
+    call_headers = ctx.post.call_args[1].get("headers", {})
+    assert call_headers.get("Authorization") == "Bearer test-token-xyz"
+
+
+@pytest.mark.asyncio
+async def test_http_transport_sends_followups_after_initialized() -> None:
+    """Followup messages should be preceded by notifications/initialized."""
+    response = httpx.Response(
+        200,
+        json={"jsonrpc": "2.0", "id": 1, "result": {}},
+    )
+    cfg = _remote_config()
+    posted_bodies: list[str] = []
+
+    async def capture_post(url: str, *, content: str, headers: Any) -> httpx.Response:
+        posted_bodies.append(content)
+        return response
+
+    with patch("mcts.fuzz.transport_http.httpx.AsyncClient") as mock_cls:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=ctx)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.post = AsyncMock(side_effect=capture_post)
+        mock_cls.return_value = ctx
+
+        await run_probe_messages_http(
+            cfg,
+            ({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},),
+            followups=({"jsonrpc": "2.0", "id": 10, "method": "tools/list", "params": {}},),
+        )
+
+    assert len(posted_bodies) == 3
+    assert "notifications/initialized" in posted_bodies[1]
+    assert "tools/list" in posted_bodies[2]
+
+
+# ---------------------------------------------------------------------------
+# FuzzRunner remote integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_collects_findings() -> None:
+    """FuzzRunner should route through HTTP transport when remote_url is set."""
+    config = _scan_config()
+    runner = FuzzRunner(config)
+
+    async def fake_http_probe(*_args: Any, **_kwargs: Any) -> tuple[str, bool]:
+        return "Traceback (most recent call last)", False
+
+    with (
+        patch(
+            "mcts.fuzz.runner.probe_remote",
+            new=AsyncMock(return_value=_fake_server()),
+        ),
+        patch(
+            "mcts.fuzz.runner.run_probe_messages_http",
+            new=AsyncMock(side_effect=fake_http_probe),
+        ),
+    ):
+        result = await runner.run_async()
+
+    assert result.probes_run >= 5
+    assert result.findings
+    assert result.findings[0].analyzer == "fuzz"
+    assert result.findings[0].evidence.get("transport") == "http"
+    assert result.findings[0].evidence.get("remote_url") == "https://mcp.example.com/mcp"
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_no_findings_on_clean_responses() -> None:
+    """Clean JSON-RPC errors from a remote server should produce zero findings."""
+    config = _scan_config()
+    runner = FuzzRunner(config)
+
+    async def clean_response(*_a: Any, **_kw: Any) -> tuple[str, bool]:
+        return '{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Not found"}}', False
+
+    with (
+        patch("mcts.fuzz.runner.probe_remote", new=AsyncMock(return_value=_fake_server())),
+        patch("mcts.fuzz.runner.run_probe_messages_http", new=AsyncMock(side_effect=clean_response)),
+    ):
+        result = await runner.run_async()
+
+    assert result.probes_run >= 5
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_aggressive_requires_consent() -> None:
+    """Aggressive fuzz on a remote server still requires --i-understand-fuzz-risk."""
+    config = _scan_config(fuzz_level="aggressive", fuzz_consent=False)
+    with pytest.raises(ValueError, match="Aggressive fuzz"):
+        await FuzzRunner(config).run_async()
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_requires_live_consent() -> None:
+    """Remote fuzz should require live consent."""
+    from mcts.probe.consent import LiveProbeConsentError
+
+    config = _scan_config(live_consent=False)
+    with pytest.raises(LiveProbeConsentError):
+        await FuzzRunner(config).run_async()
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_uses_probe_remote_for_discovery() -> None:
+    """Tool discovery for remote fuzz should use probe_remote, not probe_stdio."""
+    config = _scan_config()
+    runner = FuzzRunner(config)
+
+    mock_remote = AsyncMock(return_value=_fake_server(("tool_a", "tool_b")))
+
+    async def noop_probe(*_a: Any, **_kw: Any) -> tuple[str, bool]:
+        return "", False
+
+    with (
+        patch("mcts.fuzz.runner.probe_remote", new=mock_remote),
+        patch("mcts.fuzz.runner.run_probe_messages_http", new=AsyncMock(side_effect=noop_probe)),
+    ):
+        result = await runner.run_async()
+
+    mock_remote.assert_awaited_once()
+    assert result.probes_run >= 5
+
+
+@pytest.mark.asyncio
+async def test_stdio_runner_still_works_without_url() -> None:
+    """Stdio fuzz path should be unaffected by the remote changes."""
+    config = ScanConfig(
+        target=Path("examples/live-mcp-server/server.py"),
+        live_consent=True,
+        fuzz_level="safe",
+    )
+    runner = FuzzRunner(config)
+
+    async def fake_probe(*_a: Any, **_kw: Any) -> tuple[str, bool]:
+        return "Traceback (most recent call last)", False
+
+    with (
+        patch("mcts.fuzz.runner.resolve_live_config", return_value=None),
+        patch("mcts.fuzz.runner.probe_stdio", new=AsyncMock(return_value=_fake_server())),
+        patch("mcts.fuzz.runner.run_probe_messages", new=AsyncMock(side_effect=fake_probe)),
+    ):
+        result = await runner.run_async()
+
+    assert result.probes_run >= 5
+    assert result.findings
+    assert "transport" not in result.findings[0].evidence
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_classifier_detects_server_crash() -> None:
+    """HTTP 500 / server_error=True should be classified as a finding."""
+    config = _scan_config()
+    runner = FuzzRunner(config)
+
+    async def server_crash(*_a: Any, **_kw: Any) -> tuple[str, bool]:
+        return "500 Internal Server Error", True
+
+    with (
+        patch("mcts.fuzz.runner.probe_remote", new=AsyncMock(return_value=_fake_server())),
+        patch("mcts.fuzz.runner.run_probe_messages_http", new=AsyncMock(side_effect=server_crash)),
+    ):
+        result = await runner.run_async()
+
+    server_error_findings = [
+        f for f in result.findings if "server" in f.title.lower() or f.severity == Severity.HIGH
+    ]
+    assert server_error_findings


### PR DESCRIPTION
Closes GAP-190. Teams hosting remote MCP servers can now regression-test protocol hardening without a local subprocess.

- Add --url, --transport, --bearer-token, --header to `mcts fuzz` CLI
- Implement fuzz/transport_http.py using async httpx for raw JSON-RPC POST
- Route FuzzRunner through HTTP or stdio based on config.remote_url
- Reuse existing RemoteAuth, RemoteServerConfig, and probe_remote for tool discovery; classifier unchanged (server_error maps to process_exited)
- Mutual exclusion: --url conflicts with --command/--config
- 13 new unit tests covering transport, auth, consent, and runner routing
- Document remote fuzz usage, consent requirements, and CI examples

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [x] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest`
- [x] `uv run ruff check src tests`
- [ ] Manual CLI test (if applicable)
  ```bash
  uv run mcts scan examples/vulnerable-mcp-server/server.py
  uv run mcts scan examples/vulnerable-mcp-server/server.py -o report.json
  uv run mcts report report.json -o security-report.html
  ```

## Checklist

- [ ] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [ ] Tests added or updated
- [ ] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)
