### PR TITLE
Add doctor optional toolchain checks

### DIFF
--- a/src/mcts/cli/doctor.py
+++ b/src/mcts/cli/doctor.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import importlib.util as importlib_util
+import os
+import shutil
 import sys
 from pathlib import Path
 
 from rich.console import Console
+from rich.markup import escape
 
 from mcts import __version__
 from mcts.discovery.config import (
@@ -17,6 +21,16 @@ from mcts.discovery.config import (
 from mcts.discovery.onboarding import find_entrypoint_candidates, find_mcp_configs, format_discovery_hints
 
 console = Console()
+
+_OPTIONAL_EXTRA_CHECKS = (
+    ("[mcp] extra", "mcp", "mcp-mcts[mcp]"),
+    ("[api] extra", "fastapi", "mcp-mcts[api]"),
+)
+_OPTIONAL_CLI_CHECKS = (
+    ("semgrep CLI", "semgrep"),
+    ("pip-audit CLI", "pip-audit"),
+    ("opa CLI", "opa"),
+)
 
 
 def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> int:
@@ -72,6 +86,9 @@ def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> 
             for server_name in sorted(load_servers_dict(cfg))[:2]:
                 _deep_import_check(cfg, server_name, checks)
 
+    if deep:
+        warnings += _check_optional_toolchain(checks)
+
     if json_output:
         import json
 
@@ -92,7 +109,7 @@ def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> 
         console.print(f"[bold]mcts doctor[/bold] {path}\n")
         for status, label, detail in checks:
             icon = {"pass": "[green]✓[/green]", "warn": "[yellow]⚠[/yellow]", "fail": "[red]✗[/red]"}[status]
-            console.print(f"{icon} {label}: {detail}")
+            console.print(f"{icon} {escape(label)}: {escape(detail)}")
         if root.is_dir():
             hints = format_discovery_hints(root)
             if hints:
@@ -150,6 +167,31 @@ def _deep_import_check(config_path: Path, server_name: str, checks: list[tuple[s
         tail = (result.stderr or result.stdout or "").strip().splitlines()
         line = tail[-1] if tail else "import failed"
         checks.append(("warn", f"Import {module}", line[:120]))
+
+
+def _check_optional_toolchain(checks: list[tuple[str, str, str]]) -> int:
+    warnings = 0
+    for label, module, extra in _OPTIONAL_EXTRA_CHECKS:
+        if importlib_util.find_spec(module):
+            checks.append(("pass", label, f"module {module!r} importable"))
+        else:
+            checks.append(("warn", label, f"module {module!r} not found; install {extra} to enable"))
+            warnings += 1
+
+    for label, executable in _OPTIONAL_CLI_CHECKS:
+        found = shutil.which(executable)
+        if found:
+            checks.append(("pass", label, f"found at {found}"))
+        else:
+            checks.append(("warn", label, "not found on PATH"))
+            warnings += 1
+
+    if os.environ.get("MCTS_LLM_API_KEY"):
+        checks.append(("pass", "MCTS_LLM_API_KEY", "set"))
+    else:
+        checks.append(("warn", "MCTS_LLM_API_KEY", "not set"))
+        warnings += 1
+    return warnings
 
 
 def _rel(path: Path, root: Path) -> str:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
+import mcts.cli.doctor as doctor_module
 from mcts.cli.main import app
 
 runner = CliRunner()
@@ -30,3 +32,57 @@ def test_doctor_finds_config_and_entrypoint(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert ".mcp.json" in result.stdout
     assert "bridge.py" in result.stdout
+
+
+def test_doctor_deep_missing_optional_tools_show_warnings(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor_module.importlib_util, "find_spec", lambda _module: None)
+    monkeypatch.setattr(doctor_module.shutil, "which", lambda _executable: None)
+    monkeypatch.delenv("MCTS_LLM_API_KEY", raising=False)
+
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "[mcp] extra: module 'mcp' not found" in result.stdout
+    assert "[api] extra: module 'fastapi' not found" in result.stdout
+    assert "semgrep CLI: not found on PATH" in result.stdout
+    assert "pip-audit CLI: not found on PATH" in result.stdout
+    assert "opa CLI: not found on PATH" in result.stdout
+    assert "MCTS_LLM_API_KEY: not set" in result.stdout
+
+
+def test_doctor_deep_present_optional_tools_show_pass_lines(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor_module.importlib_util, "find_spec", lambda _module: SimpleNamespace())
+    monkeypatch.setattr(doctor_module.shutil, "which", lambda executable: f"C:\\tools\\{executable}.exe")
+    monkeypatch.setenv("MCTS_LLM_API_KEY", "test-key")
+
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "[mcp] extra: module 'mcp' importable" in result.stdout
+    assert "[api] extra: module 'fastapi' importable" in result.stdout
+    assert "semgrep CLI: found at C:\\tools\\semgrep.exe" in result.stdout
+    assert "pip-audit CLI: found at C:\\tools\\pip-audit.exe" in result.stdout
+    assert "opa CLI: found at C:\\tools\\opa.exe" in result.stdout
+    assert "MCTS_LLM_API_KEY: set" in result.stdout
+
+
+def test_doctor_deep_missing_optional_extras_do_not_fail_core_only_install(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        doctor_module.importlib_util,
+        "find_spec",
+        lambda module: None if module in {"mcp", "fastapi"} else SimpleNamespace(),
+    )
+
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "[mcp] extra: module 'mcp' not found" in result.stdout
+    assert "[api] extra: module 'fastapi' not found" in result.stdout
+
+
+def test_doctor_deep_exits_zero(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Fixes #212

Summary:

* Added `mcts doctor --deep` checks for optional `[mcp]` and `[api]` extras.
* Added optional CLI checks for `semgrep`, `pip-audit`, and `opa`.
* Added `MCTS_LLM_API_KEY` readiness warning.
* Missing optional extras/tools now show warnings only and do not fail core-only installs.
* Escaped Rich output labels/details so `[mcp]` and `[api]` display literally.
* Added doctor tests for missing and present optional toolchain cases.

Test:

* `.\.venv\Scripts\python.exe -m pytest tests/test_doctor.py`
* Result: `6 passed`
