### PR TITLE
fix(probe): Stop jailbreak probe from always reporting acceptance

### DIFF
--- a/src/mcts/probe/jailbreak.py
+++ b/src/mcts/probe/jailbreak.py
@@ -103,9 +103,9 @@ def _tool_accepts_free_text(tool: MCPTool) -> bool:
 
 
 def _evaluate_payload(payload_text: str, surface: dict[str, str]) -> tuple[bool, float]:
-    combined = f"{surface.get('text', '')}\n{payload_text}"
-    if _ACCEPTANCE_RE.search(combined):
+    surface_text = surface.get("text", "")
+    if _ACCEPTANCE_RE.search(surface_text):
         return True, 0.82
-    if surface.get("kind") == "tool_input" and len(surface.get("text", "")) < 12:
+    if surface.get("kind") == "tool_input" and len(surface_text) < 12:
         return True, 0.75
     return False, 0.9

--- a/tests/test_jailbreak_live.py
+++ b/tests/test_jailbreak_live.py
@@ -35,6 +35,26 @@ def test_jailbreak_analyzer_reports_live_acceptance() -> None:
     assert any(f.id == "jailbreak-live-payload-accepted" for f in findings)
 
 
+def test_benign_server_produces_no_accepted_events() -> None:
+    server = MCPServerInfo(
+        name="safe-server",
+        instructions="This server manages database records securely.",
+        tools=[
+            MCPTool(
+                name="list_records",
+                description="List all database records",
+                input_schema={"type": "object", "properties": {"limit": {"type": "integer"}}},
+            )
+        ],
+    )
+    events = events_from_jailbreak_probe(server)
+    assert events
+    accepted = [e for e in events if e.get("accepted")]
+    assert not accepted, f"Benign server should have 0 accepted events, got {len(accepted)}"
+    summary = summarize_jailbreak_events(events)
+    assert summary["accepted_count"] == 0
+
+
 def test_scanner_merges_jailbreak_events_when_enabled() -> None:
     server = MCPServerInfo(
         name="demo",


### PR DESCRIPTION
`_evaluate_payload` searched a combined string of surface text + payload text against `_ACCEPTANCE_RE`. Since every payload contains keywords like "ignore previous" and "developer mode", the regex always matched the payload itself, producing ~100% false positive acceptance rate.
Check only the surface text so acceptance reflects actual server metadata vulnerability, not the probe's own wording.

Adds a negative-case test: a benign server now correctly produces zero accepted events.

## Summary

`_evaluate_payload` in `src/mcts/probe/jailbreak.py` concatenated surface text with payload text before regex matching. Every jailbreak payload inherently contains `_ACCEPTANCE_RE` keywords (`ignore previous`, `developer mode`, `override`, etc.), so `accepted` was always `True`, producing bogus CRITICAL findings on every `--enable-jailbreak-live` scan.

Fix: evaluate only the surface text against `_ACCEPTANCE_RE`.

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest` — 4/4 jailbreak tests pass
- [x] `uv run ruff check src tests` — all checks passed
- [ ] Manual CLI test (if applicable)

## Checklist

- [ ] CHANGELOG.md updated (if user-facing)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed