### PR TITLE
fix(cli): allow mcts scan --url without TARGET (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Allow `mcts scan --url https://host/mcp` without an explicit TARGET positional argument.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -529,8 +529,8 @@ def scan(
         )
         raise typer.Exit(code=2)
 
-    if not machine_wide and target is None:
-        console.print("[red]Error:[/red] TARGET is required unless --machine-wide is set.")
+    if not machine_wide and target is None and not url:
+        console.print("[red]Error:[/red] TARGET is required unless --machine-wide or --url is set.")
         raise typer.Exit(code=2)
 
     if target is None:

--- a/tests/test_auto_scan.py
+++ b/tests/test_auto_scan.py
@@ -67,3 +67,13 @@ def test_scan_dot_allowed_without_config(tmp_path: Path) -> None:
     server.write_text("print('not mcp')\n")
     result = runner.invoke(app, ["scan", str(tmp_path), "--no-progress", "--no-save"])
     assert result.exit_code in (0, 1)
+
+
+def test_scan_url_without_target_does_not_require_positional() -> None:
+    result = runner.invoke(
+        app,
+        ["scan", "--url", "https://example.com/mcp", "--no-progress", "--no-save"],
+    )
+    assert "TARGET is required" not in result.stdout
+    assert result.exit_code == 2
+    assert "consent" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Allow `mcts scan --url <endpoint>` without a redundant positional `TARGET` by defaulting the scan target to the current directory when `--url` is set.

Fixes #189

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_auto_scan.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test
  ```bash
  uv run mcts scan --url http://127.0.0.1:8000/mcp
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

Made with [Cursor](https://cursor.com)