### PR TITLE
fix(auto): error on ambiguous multi-config discovery (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Fail `--auto` with a clear error when multiple MCP config files or entrypoint candidates are found instead of silently scanning the repo root.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/cli/auto.py
+++ b/src/mcts/cli/auto.py
@@ -29,8 +29,7 @@ def resolve_auto_scan(
     if len(candidates) > 1:
         listed = ", ".join(str(path.relative_to(root)) for path in candidates[:5])
         raise AutoScanError(
-            f"Multiple MCP entrypoint candidates under {root}; pass TARGET explicitly. "
-            f"Candidates: {listed}"
+            f"Multiple MCP entrypoint candidates under {root}; pass TARGET explicitly. Candidates: {listed}"
         )
     if len(candidates) == 1:
         return base_config.model_copy(update={"target": candidates[0]})

--- a/src/mcts/cli/auto.py
+++ b/src/mcts/cli/auto.py
@@ -26,10 +26,26 @@ def resolve_auto_scan(
     """Resolve scan target/config for --auto mode (static only)."""
     root = target.expanduser().resolve()
     candidates = find_entrypoint_candidates(root) if root.is_dir() else []
+    if len(candidates) > 1:
+        listed = ", ".join(str(path.relative_to(root)) for path in candidates[:5])
+        raise AutoScanError(
+            f"Multiple MCP entrypoint candidates under {root}; pass TARGET explicitly. "
+            f"Candidates: {listed}"
+        )
     if len(candidates) == 1:
         return base_config.model_copy(update={"target": candidates[0]})
 
     configs = find_mcp_configs(root) if root.is_dir() else []
+    if len(configs) > 1:
+        lines: list[str] = []
+        for cfg in configs:
+            servers = list_servers(cfg)
+            rel = cfg.relative_to(root).as_posix()
+            lines.append(f"{rel}: {', '.join(servers) if servers else '(no servers)'}")
+        raise AutoScanError(
+            "Multiple MCP config files found; pass --config and --server explicitly.\n"
+            + "\n".join(f"  • {line}" for line in lines)
+        )
     if len(configs) == 1:
         servers = list_servers(configs[0])
         if auto_server:

--- a/tests/test_auto_scan.py
+++ b/tests/test_auto_scan.py
@@ -41,6 +41,26 @@ def test_auto_multiple_servers_requires_flag(tmp_path: Path) -> None:
     assert exc.value.multiple_servers == ["a", "b"]
 
 
+def test_auto_multiple_config_files_error(tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"a": {"command": "python"}}}))
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    (cursor / "mcp.json").write_text(json.dumps({"mcpServers": {"b": {"command": "python"}}}))
+    base = ScanConfig(target=tmp_path)
+    with pytest.raises(AutoScanError, match="Multiple MCP config files"):
+        resolve_auto_scan(tmp_path, base)
+
+
+def test_auto_multiple_entrypoints_error(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text("FastMCP\n@tool\ndef a(): pass\n")
+    nested = tmp_path / "pkg"
+    nested.mkdir()
+    (nested / "bridge.py").write_text("FastMCP\n@tool\ndef b(): pass\n")
+    base = ScanConfig(target=tmp_path)
+    with pytest.raises(AutoScanError, match="Multiple MCP entrypoint candidates"):
+        resolve_auto_scan(tmp_path, base)
+
+
 def test_auto_server_flag(tmp_path: Path) -> None:
     config = tmp_path / ".mcp.json"
     config.write_text(json.dumps({"mcpServers": {"a": {"command": "python"}, "b": {"command": "python"}}}))


### PR DESCRIPTION
## Summary

When `--auto` discovers multiple MCP config files or multiple entrypoint candidates, fail with a clear error that lists the ambiguous options instead of silently picking one.

Fixes #188

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_auto_scan.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test (if applicable)
  ```bash
  # repo with multiple mcp.json / server entrypoints should print the candidate list
  uv run mcts scan --auto .
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

> **Note:** May conflict with #189 on `tests/test_auto_scan.py` and `CHANGELOG.md`; merge #189 first or rebase after it lands.
