### PR TITLE
fix(pip-audit): surface skip reasons when audit cannot run (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Log when `--pip-audit` is skipped (missing CLI or dependency manifest) and keep CVE findings when the audit runs successfully.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/analyzers/vulnerable_package.py
+++ b/src/mcts/analyzers/vulnerable_package.py
@@ -23,10 +23,20 @@ class VulnerablePackageAnalyzer(BaseAnalyzer):
     def analyze(self, server: MCPServerInfo) -> list[Finding]:
         del server
         if not shutil.which("pip-audit"):
-            return []
+            return [
+                _skip_finding(
+                    "pip-audit CLI not found on PATH",
+                    "Install pip-audit (`uv sync --extra supplychain`) or remove --pip-audit.",
+                )
+            ]
         req = self._find_requirements()
         if req is None:
-            return []
+            return [
+                _skip_finding(
+                    "no requirements.txt or pyproject.toml found in scan target",
+                    "Add a Python dependency manifest or scan a directory that contains one.",
+                )
+            ]
         return self._audit_file(req)
 
     def _find_requirements(self) -> Path | None:
@@ -80,3 +90,17 @@ class VulnerablePackageAnalyzer(BaseAnalyzer):
                     )
                 )
         return findings
+
+
+def _skip_finding(reason: str, recommendation: str) -> Finding:
+    return Finding(
+        id="pip-audit-skipped",
+        analyzer="vulnerable_package",
+        title="pip-audit scan skipped",
+        description=reason,
+        severity=Severity.LOW,
+        recommendation=recommendation,
+        technique_id=None,
+        confidence=1.0,
+        evidence={"skipped": True, "reason": reason},
+    )

--- a/tests/test_vulnerable_package.py
+++ b/tests/test_vulnerable_package.py
@@ -1,0 +1,51 @@
+"""Tests for pip-audit dependency scanning."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from mcts.analyzers.vulnerable_package import VulnerablePackageAnalyzer
+from mcts.mcp.models import MCPServerInfo
+
+
+def test_pip_audit_skip_when_cli_missing(tmp_path: Path) -> None:
+    with patch("mcts.analyzers.vulnerable_package.shutil.which", return_value=None):
+        findings = VulnerablePackageAnalyzer(tmp_path).analyze(MCPServerInfo(name="x"))
+    assert len(findings) == 1
+    assert findings[0].id == "pip-audit-skipped"
+    assert "not found on PATH" in findings[0].description
+
+
+def test_pip_audit_skip_when_no_manifest(tmp_path: Path) -> None:
+    with patch("mcts.analyzers.vulnerable_package.shutil.which", return_value="/usr/bin/pip-audit"):
+        findings = VulnerablePackageAnalyzer(tmp_path).analyze(MCPServerInfo(name="x"))
+    assert len(findings) == 1
+    assert findings[0].id == "pip-audit-skipped"
+    assert "requirements.txt" in findings[0].description
+
+
+def test_pip_audit_reports_cve_findings(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text("requests==2.0.0\n", encoding="utf-8")
+    audit_payload = [
+        {
+            "name": "requests",
+            "version": "2.0.0",
+            "vulns": [{"id": "CVE-TEST-1", "description": "Test vulnerability"}],
+        }
+    ]
+
+    class FakeProc:
+        returncode = 1
+        stdout = json.dumps(audit_payload)
+        stderr = ""
+
+    with (
+        patch("mcts.analyzers.vulnerable_package.shutil.which", return_value="/usr/bin/pip-audit"),
+        patch("mcts.analyzers.vulnerable_package.subprocess.run", return_value=FakeProc()),
+    ):
+        findings = VulnerablePackageAnalyzer(tmp_path).analyze(MCPServerInfo(name="x"))
+
+    assert any(f.id.startswith("pip-audit-requests-") for f in findings)
+    assert not any(f.id == "pip-audit-skipped" for f in findings)


### PR DESCRIPTION
## Summary

Emit a low-severity `pip-audit-skipped` finding when `--pip-audit` is requested but the `pip-audit` CLI or dependency manifest is missing, while preserving CVE findings when the audit runs successfully.

Fixes #185

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_vulnerable_package.py`
- [x] `uv run ruff check src tests`

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

Made with [Cursor](https://cursor.com)