### PR TITLE
fix(semgrep): report when SAST scan is skipped (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Surface a clear skip reason when `--semgrep` is enabled but the Semgrep CLI is unavailable or the scan fails before producing results.
+
+### Changed
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/analyzers/semgrep_adapter.py
+++ b/src/mcts/analyzers/semgrep_adapter.py
@@ -112,4 +112,28 @@ def _findings_from_payload(payload: dict, *, analyzer: str) -> list[Finding]:
                 },
             )
         )
+    if not findings:
+        for err in payload.get("errors") or []:
+            if not isinstance(err, dict):
+                continue
+            message = str(err.get("message") or "").strip()
+            if not message:
+                continue
+            findings.append(
+                Finding(
+                    id="semgrep-skipped",
+                    analyzer=analyzer,
+                    title="Semgrep scan skipped",
+                    description=message,
+                    severity=Severity.LOW,
+                    recommendation=(
+                        "Install the semgrep CLI (`uv sync --extra semgrep`) or remove --semgrep "
+                        "when SAST is not required."
+                    ),
+                    technique_id=None,
+                    confidence=1.0,
+                    evidence={"skipped": True, "reason": message},
+                )
+            )
+            break
     return findings

--- a/tests/test_semgrep_adapter.py
+++ b/tests/test_semgrep_adapter.py
@@ -74,6 +74,17 @@ def test_run_semgrep_scan_missing_cli(tmp_path: Path) -> None:
     assert payload["errors"]
 
 
+def test_findings_from_payload_reports_semgrep_skip_reason() -> None:
+    payload = {
+        "results": [],
+        "errors": [{"message": "semgrep CLI not found on PATH"}],
+    }
+    findings = _findings_from_payload(payload, analyzer="semgrep_sast")
+    assert len(findings) == 1
+    assert findings[0].id == "semgrep-skipped"
+    assert "not found on PATH" in findings[0].description
+
+
 def test_run_semgrep_scan_parses_json(tmp_path: Path) -> None:
     rules = tmp_path / "rules.yaml"
     rules.write_text("rules: []\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Emit a low-severity `semgrep-skipped` finding when `--semgrep` is enabled but the Semgrep CLI is unavailable or the scan fails before producing rule matches, so skipped SAST runs are visible in reports.

Fixes #184

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_semgrep_adapter.py`
- [x] `uv run ruff check src tests`

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)
