### PR TITLE
fix(readiness): warn when optional OPA or LLM checks unavailable (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Warn in `mcts readiness` when `--opa` or `--llm-judge` is requested but optional dependencies are missing.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/readiness/runner.py
+++ b/src/mcts/readiness/runner.py
@@ -44,8 +44,7 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
                 title="LLM readiness judge skipped",
                 description=_llm_unavailable_reason(),
                 recommendation=(
-                    "Set MCTS_LLM_API_KEY and install litellm (`uv sync --extra llm`), "
-                    "or omit --llm-judge."
+                    "Set MCTS_LLM_API_KEY and install litellm (`uv sync --extra llm`), or omit --llm-judge."
                 ),
             )
         )

--- a/src/mcts/readiness/runner.py
+++ b/src/mcts/readiness/runner.py
@@ -28,6 +28,28 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
     llm = ReadinessLlmJudge(model=config.readiness_llm_model) if config.readiness_llm else None
     findings: list[Finding] = []
 
+    if config.readiness_opa and (opa is None or not opa.is_available()):
+        findings.append(
+            _optional_check_unavailable(
+                check_id="readiness-opa-unavailable",
+                title="OPA readiness checks skipped",
+                description=_opa_unavailable_reason(opa),
+                recommendation="Install the opa CLI on PATH or omit --opa when policy checks are not required.",
+            )
+        )
+    if config.readiness_llm and (llm is None or not llm.is_available()):
+        findings.append(
+            _optional_check_unavailable(
+                check_id="readiness-llm-unavailable",
+                title="LLM readiness judge skipped",
+                description=_llm_unavailable_reason(),
+                recommendation=(
+                    "Set MCTS_LLM_API_KEY and install litellm (`uv sync --extra llm`), "
+                    "or omit --llm-judge."
+                ),
+            )
+        )
+
     for tool in server.tools:
         tool_def = _tool_def(tool)
         findings.extend(check_tool_readiness(tool))
@@ -72,3 +94,45 @@ def _tool_def(tool: MCPTool) -> dict:
         "description": tool.description,
         "inputSchema": tool.input_schema,
     }
+
+
+def _optional_check_unavailable(
+    *,
+    check_id: str,
+    title: str,
+    description: str,
+    recommendation: str,
+) -> Finding:
+    return Finding(
+        id=check_id,
+        analyzer="readiness",
+        title=title,
+        description=description,
+        severity=Severity.MEDIUM,
+        recommendation=recommendation,
+        technique_id=None,
+        confidence=1.0,
+        evidence={"skipped": True, "optional_check": True},
+    )
+
+
+def _opa_unavailable_reason(opa: OpaProvider | None) -> str:
+    if opa is None:
+        return "OPA readiness checks were requested but the provider was not initialized."
+    if opa._opa_path is None:
+        return "OPA readiness checks were requested but the opa CLI was not found on PATH."
+    if not opa.policies_dir.exists():
+        return f"OPA readiness checks were requested but policies were not found at {opa.policies_dir}."
+    return "OPA readiness checks were requested but OPA is not available."
+
+
+def _llm_unavailable_reason() -> str:
+    import os
+
+    if not os.environ.get("MCTS_LLM_API_KEY"):
+        return "LLM readiness review was requested but MCTS_LLM_API_KEY is not set."
+    try:
+        import litellm  # noqa: F401
+    except ImportError:
+        return "LLM readiness review was requested but litellm is not installed."
+    return "LLM readiness review was requested but the judge is not available."

--- a/src/mcts/readiness/runner.py
+++ b/src/mcts/readiness/runner.py
@@ -34,7 +34,9 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
                 check_id="readiness-opa-unavailable",
                 title="OPA readiness checks skipped",
                 description=_opa_unavailable_reason(opa),
-                recommendation="Install the opa CLI on PATH or omit --opa when policy checks are not required.",
+                recommendation=(
+                    "Install the opa CLI on PATH or omit --opa when policy checks are not required."
+                ),
             )
         )
     if config.readiness_llm and (llm is None or not llm.is_available()):

--- a/tests/test_readiness_and_api.py
+++ b/tests/test_readiness_and_api.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import pytest
 
 from mcts.analyzers.surface_context import scan_surfaces
+from mcts.core.config import ScanConfig
 from mcts.mcp.models import MCPResource, MCPServerInfo, MCPTool, SurfaceScanOptions
 from mcts.readiness.heuristics import check_tool_readiness, readiness_score
+from mcts.readiness.runner import run_readiness
 from mcts.sast.typescript.sinks import detect_typescript_sinks
 
 
@@ -26,6 +28,33 @@ def test_readiness_score_deductions():
     tool = MCPTool(name="x", description="short")
     findings = check_tool_readiness(tool)
     assert readiness_score(findings) < 100
+
+
+def test_readiness_warns_when_opa_requested_but_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mcts.readiness.runner.Scanner", _FakeScanner)
+    monkeypatch.setattr("mcts.readiness.runner.OpaProvider.is_available", lambda self: False)
+    report = run_readiness(ScanConfig(target=".", readiness_opa=True))
+    assert any(f.id == "readiness-opa-unavailable" for f in report.findings)
+
+
+def test_readiness_warns_when_llm_requested_but_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MCTS_LLM_API_KEY", raising=False)
+    monkeypatch.setattr("mcts.readiness.runner.Scanner", _FakeScanner)
+    report = run_readiness(ScanConfig(target=".", readiness_llm=True))
+    assert any(f.id == "readiness-llm-unavailable" for f in report.findings)
+
+
+class _FakeScanner:
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.client = self
+
+    def discover(self) -> MCPServerInfo:
+        return MCPServerInfo(
+            name="demo",
+            tools=[MCPTool(name="echo", description="Echo user input back to the caller safely.")],
+        )
 
 
 def test_resource_mime_allowlist_filters_surfaces():


### PR DESCRIPTION
## Summary

Surface explicit readiness findings when `--opa` or `--llm-judge` is requested but required dependencies are missing (`opa` CLI, `litellm`, or API key), without failing the overall readiness run.

Fixes #187

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_readiness_and_api.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test (if applicable)
  ```bash
  uv run mcts readiness examples/vulnerable-mcp-server/server.py --opa
  uv run mcts readiness examples/vulnerable-mcp-server/server.py --llm-judge
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

> **Note:** May conflict with #181 on `src/mcts/readiness/runner.py`, `tests/test_readiness_and_api.py`, and `CHANGELOG.md`; merge #181 after this PR or rebase.

