### PR TITLE
fix(readiness): fail when zero MCP tools are discovered (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -1301,6 +1301,9 @@ def readiness(
     )
     console.print(f"[green]Saved[/green] {output_path}")
 
+    if report.tools_checked == 0:
+        raise typer.Exit(code=1)
+
 
 @app.command(name="serve")
 def serve_api(

--- a/src/mcts/readiness/runner.py
+++ b/src/mcts/readiness/runner.py
@@ -36,6 +36,28 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
         if llm and llm.is_available():
             findings.extend(llm.analyze_tool(tool_def, tool.name))
 
+    if not server.tools:
+        findings.append(
+            Finding(
+                id="readiness-no-tools-discovered",
+                analyzer="readiness",
+                title="No MCP tools discovered",
+                description=(
+                    "Readiness checks apply to MCP tools, but discovery found zero tools. "
+                    "Agent repos with only SKILL.md or prompt markdown need a discoverable MCP "
+                    "entrypoint, or use live/snapshot discovery before running readiness."
+                ),
+                severity=Severity.HIGH,
+                recommendation=(
+                    "Point readiness at an MCP server entrypoint, run static discovery on tool "
+                    "sources, or export tools via mcts snapshot for offline scans."
+                ),
+                technique_id=None,
+                confidence=0.9,
+                evidence={"readiness_rule": "HEUR-000", "tools_discovered": 0},
+            )
+        )
+
     if not server.version or server.version == "0.0.0":
         findings.append(
             Finding(
@@ -52,7 +74,11 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
         )
 
     score = readiness_score(findings)
-    production_ready = score >= 70 and not any(f.severity == Severity.CRITICAL for f in findings)
+    production_ready = (
+        bool(server.tools)
+        and score >= 70
+        and not any(f.severity == Severity.CRITICAL for f in findings)
+    )
     for finding in findings:
         finding.evidence.setdefault("readiness_score", score)
         finding.evidence.setdefault("production_ready", production_ready)

--- a/src/mcts/readiness/runner.py
+++ b/src/mcts/readiness/runner.py
@@ -75,9 +75,7 @@ def run_readiness(config: ScanConfig) -> ReadinessReport:
 
     score = readiness_score(findings)
     production_ready = (
-        bool(server.tools)
-        and score >= 70
-        and not any(f.severity == Severity.CRITICAL for f in findings)
+        bool(server.tools) and score >= 70 and not any(f.severity == Severity.CRITICAL for f in findings)
     )
     for finding in findings:
         finding.evidence.setdefault("readiness_score", score)

--- a/tests/test_readiness_and_api.py
+++ b/tests/test_readiness_and_api.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+from typer.testing import CliRunner
 
 from mcts.analyzers.surface_context import scan_surfaces
+from mcts.cli.main import app
+from mcts.core.config import ScanConfig
 from mcts.mcp.models import MCPResource, MCPServerInfo, MCPTool, SurfaceScanOptions
 from mcts.readiness.heuristics import check_tool_readiness, readiness_score
+from mcts.readiness.runner import run_readiness
 from mcts.sast.typescript.sinks import detect_typescript_sinks
+
+runner = CliRunner()
 
 
 def test_readiness_heur_001_missing_timeout():
@@ -26,6 +34,53 @@ def test_readiness_score_deductions():
     tool = MCPTool(name="x", description="short")
     findings = check_tool_readiness(tool)
     assert readiness_score(findings) < 100
+
+
+def test_readiness_fails_when_no_tools_discovered(tmp_path: Path) -> None:
+    skill = tmp_path / "skills" / "deploy"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Deploy\nRun the deployment workflow.\n", encoding="utf-8")
+    report = run_readiness(ScanConfig(target=tmp_path, discover_instructions=True))
+    assert report.tools_checked == 0
+    assert not report.production_ready
+    assert any(f.id == "readiness-no-tools-discovered" for f in report.findings)
+
+
+def test_readiness_passes_when_tools_discovered(tmp_path: Path) -> None:
+    server_py = tmp_path / "server.py"
+    server_py.write_text(
+        "from mcp.server import Server\n"
+        "server = Server('demo')\n"
+        "@server.tool()\n"
+        "def greet(name: str) -> str:\n"
+        '    """Say hello to the user with a friendly greeting message."""\n'
+        "    return name\n",
+        encoding="utf-8",
+    )
+    report = run_readiness(ScanConfig(target=server_py))
+    assert report.tools_checked >= 1
+    assert not any(f.id == "readiness-no-tools-discovered" for f in report.findings)
+
+
+def test_readiness_cli_exits_one_only_when_no_tools(tmp_path: Path) -> None:
+    skill = tmp_path / "skills" / "deploy"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Deploy\nRun the deployment workflow.\n", encoding="utf-8")
+    no_tools = runner.invoke(app, ["readiness", str(tmp_path)])
+    assert no_tools.exit_code == 1
+
+    server_py = tmp_path / "server.py"
+    server_py.write_text(
+        "from mcp.server import Server\n"
+        "server = Server('demo')\n"
+        "@server.tool()\n"
+        "def greet(name: str) -> str:\n"
+        '    """Say hello to the user with a friendly greeting message."""\n'
+        "    return name\n",
+        encoding="utf-8",
+    )
+    with_tools = runner.invoke(app, ["readiness", str(server_py)])
+    assert with_tools.exit_code == 0
 
 
 def test_resource_mime_allowlist_filters_surfaces():


### PR DESCRIPTION
## Summary

Fail readiness checks when no MCP tools are discovered: emit a HIGH `readiness-no-tools-discovered` finding, mark `production_ready` false, and exit non-zero from `mcts readiness` only when `tools_checked == 0` (low readiness scores with tools still exit 0).

Fixes #181

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_readiness_and_api.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test (if applicable)
  ```bash
  # skills-only repo (no tools) — expect exit 1
  uv run mcts readiness /path/to/skills-only-repo
  # entrypoint with tools — expect exit 0 even if score is low
  uv run mcts readiness examples/vulnerable-mcp-server/server.py
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

> **Note:** Conflicts likely with #187 (`runner.py`, `test_readiness_and_api.py`) and #189 (`main.py`) if merged in parallel; rebase onto `main` after those land.

Made with [Cursor](https://cursor.com)