### PR TITLE
fix(snapshot): exit 2 when live launch config is missing (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
+- Return exit code 2 with a clear message when `mcts snapshot` cannot resolve a live launch configuration.
 
 ## [0.1.2] - 2026-06-10
 

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -1516,6 +1516,9 @@ def snapshot(
     except MCPStartupError as exc:
         _print_startup_error(exc)
         raise typer.Exit(code=2) from exc
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
     except RuntimeError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=2) from exc

--- a/tests/test_snapshot_cli.py
+++ b/tests/test_snapshot_cli.py
@@ -6,10 +6,22 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+from typer.testing import CliRunner
+
+from mcts.cli.main import app
 from mcts.core.config import ScanConfig
 from mcts.core.scanner import Scanner
 from mcts.mcp.models import MCPServerInfo, MCPTool
 from mcts.snapshot.export import export_snapshot, snapshot_dict_from_server
+
+runner = CliRunner()
+
+
+def test_snapshot_missing_launch_config_exit_2(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["snapshot", str(tmp_path), "--i-understand-live-risk"])
+    assert result.exit_code == 2
+    assert "Live scan requires" in result.output
+    assert "Traceback" not in result.output
 
 
 def test_snapshot_dict_shape() -> None:


### PR DESCRIPTION
## Summary

Catch `ValueError` from `resolve_live_config()` in the `mcts snapshot` command so missing launch configuration exits **2** with a clear message instead of exit **1** with a Python traceback. Aligns snapshot with `scan`, `fuzz`, and `pentest` live error handling.

Fixes #149

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_snapshot_cli.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test
  ```bash
  uv run mcts snapshot . --i-understand-live-risk
  # expect exit 2, "Live scan requires...", no traceback
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

