### PR TITLE
fix(cli): validate live launch config before consent (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate governance `--policy` files before scan execution so missing or invalid policy files fail before reports are written.
 
+### Changed
+
+- Validate resolvable live launch configuration before the consent gate on `mcts snapshot` and `mcts fuzz`.
+
 ## [0.1.2] - 2026-06-10
 
 ### Added

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -125,6 +125,27 @@ def _print_startup_error(exc) -> None:
     )
 
 
+def _validate_live_launch(config: ScanConfig) -> None:
+    """Resolve stdio launch parameters without starting a subprocess."""
+    from mcts.discovery.config import ConfigDiscoveryError
+    from mcts.discovery.live_config import resolve_live_config
+
+    try:
+        resolve_live_config(config)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+    except ConfigDiscoveryError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+
+
+def _require_config_server(config: Path | None, server: str | None) -> None:
+    if config and not server:
+        console.print("[red]Error:[/red] --config requires --server.")
+        raise typer.Exit(code=2)
+
+
 def _print_discovery_hints(target: Path) -> None:
     from mcts.discovery.onboarding import format_discovery_hints
 
@@ -1170,16 +1191,7 @@ def fuzz(
     if target == Path(".") and config is None:
         _print_discovery_hints(target)
 
-    if not live_consent_granted(flag=understand_live_risk):
-        console.print(
-            "[red]Fuzzing requires live server consent.[/red] Pass --i-understand-live-risk "
-            "or set MCTS_LIVE_OK=1 in CI."
-        )
-        raise typer.Exit(code=2)
-
-    if config and not server:
-        console.print("[red]Error:[/red] --config requires --server.")
-        raise typer.Exit(code=2)
+    _require_config_server(config, server)
 
     level = fuzz_level.lower()
     if level not in {item.value for item in FuzzLevel}:
@@ -1213,6 +1225,14 @@ def fuzz(
         fuzz_consent=understand_fuzz_risk,
         theme=resolved_theme.name.value,
     )
+    _validate_live_launch(fuzz_config)
+
+    if not live_consent_granted(flag=understand_live_risk):
+        console.print(
+            "[red]Fuzzing requires live server consent.[/red] Pass --i-understand-live-risk "
+            "or set MCTS_LIVE_OK=1 in CI."
+        )
+        raise typer.Exit(code=2)
 
     try:
         result = FuzzRunner(fuzz_config).run()
@@ -1487,16 +1507,7 @@ def snapshot(
     from mcts.probe.startup_errors import MCPStartupError
     from mcts.snapshot.export import export_snapshot
 
-    if not live_consent_granted(flag=understand_live_risk):
-        console.print(
-            "[red]Snapshot export requires live consent.[/red] Pass --i-understand-live-risk "
-            "or set MCTS_LIVE_OK=1 in CI."
-        )
-        raise typer.Exit(code=2)
-
-    if config and not server:
-        console.print("[red]Error:[/red] --config requires --server.")
-        raise typer.Exit(code=2)
+    _require_config_server(config, server)
 
     scan_target = config if (config and target == Path(".")) else target
     live_args = [part.strip() for part in args.split(",") if part.strip()] if args else []
@@ -1511,6 +1522,15 @@ def snapshot(
         stderr_file=stderr_file,
         expand_vars=expand_vars,
     )
+    _validate_live_launch(snap_config)
+
+    if not live_consent_granted(flag=understand_live_risk):
+        console.print(
+            "[red]Snapshot export requires live consent.[/red] Pass --i-understand-live-risk "
+            "or set MCTS_LIVE_OK=1 in CI."
+        )
+        raise typer.Exit(code=2)
+
     try:
         payload = export_snapshot(snap_config)
     except MCPStartupError as exc:

--- a/tests/test_live_launch_validation.py
+++ b/tests/test_live_launch_validation.py
@@ -1,0 +1,47 @@
+"""CLI tests for live launch validation ordering (config before consent)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mcts.cli.main import app
+
+runner = CliRunner()
+
+
+def test_snapshot_config_error_before_consent(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["snapshot", str(tmp_path), "--config", "mcp.json"])
+    assert result.exit_code == 2
+    assert "--config requires --server" in result.output
+    assert "live consent" not in result.output.lower()
+
+
+def test_snapshot_missing_launch_before_consent(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["snapshot", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "Live scan requires" in result.output
+    assert "live consent" not in result.output.lower()
+
+
+def test_snapshot_consent_required_after_valid_launch(tmp_path: Path) -> None:
+    server_py = tmp_path / "server.py"
+    server_py.write_text("print('stub')\n", encoding="utf-8")
+    result = runner.invoke(app, ["snapshot", str(server_py)])
+    assert result.exit_code == 2
+    assert "live consent" in result.output.lower()
+
+
+def test_fuzz_config_error_before_consent(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["fuzz", str(tmp_path), "--config", "mcp.json"])
+    assert result.exit_code == 2
+    assert "--config requires --server" in result.output
+    assert "live consent" not in result.output.lower()
+
+
+def test_fuzz_missing_launch_before_consent(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["fuzz", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "Live scan requires" in result.output
+    assert "live consent" not in result.output.lower()


### PR DESCRIPTION
## Summary

Validate resolvable live launch configuration (`--config`/`--server`, `--command`, or `.py` target) **before** the live consent gate on `mcts snapshot` and `mcts fuzz`. Operators see one actionable config error per run instead of fixing consent first and then discovering missing `--server` or launch params.

Fixes #222

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [x] `uv run pytest tests/test_live_launch_validation.py tests/test_snapshot_cli.py`
- [x] `uv run ruff check src tests`
- [x] Manual CLI test
  ```bash
  # config error before consent
  uv run mcts snapshot . --config .mcp.json
  # expect exit 2, "--config requires --server", no consent message

  # consent only after valid launch target
  uv run mcts snapshot examples/vulnerable-mcp-server/server.py
  # expect exit 2, live consent message
  ```

## Checklist

- [x] CHANGELOG.md updated (if user-facing) — see [Keep a Changelog](../CHANGELOG.md)
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [ ] Docs updated if CLI behavior or report output changed — see [Documentation index](docs/index.md) (guides live under `docs/get-started/`, `docs/scanning/`, `docs/platform/`, etc.)

> **Note:** Overlaps #241 on `main.py` and `CHANGELOG.md`. Merge #241 first, then rebase this branch onto `main` if needed.