### PR TITLE
fix(cli): distinct HTML/SARIF paths for surface scan subcommands (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log when `--pip-audit` is skipped (missing CLI or dependency manifest) and keep CVE findings when the audit runs successfully.
 - Allow `mcts scan --url https://host/mcp` without an explicit TARGET positional argument.
 - Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
+- Write distinct HTML and SARIF artifacts for `scan-prompts`, `scan-resources`, and `scan-instructions` instead of overwriting `scan-report.html`.
 
 ### Changed
 

--- a/src/mcts/output/artifacts.py
+++ b/src/mcts/output/artifacts.py
@@ -45,8 +45,14 @@ def persist_scan_artifacts(
     report = _report_with_scan_history(report)
 
     json_out = resolve_output_path(json_path, "scan-report.json")
-    html_out = resolve_output_path(html_path, "scan-report.html")
-    sarif_out = resolve_output_path(sarif_path, "scan-report.sarif")
+    if html_path is None:
+        html_out = json_out.with_suffix(".html")
+    else:
+        html_out = resolve_output_path(html_path, "scan-report.html")
+    if sarif_path is None:
+        sarif_out = json_out.with_suffix(".sarif")
+    else:
+        sarif_out = resolve_output_path(sarif_path, "scan-report.sarif")
 
     if write_json:
         json_out.write_text(report.model_dump_json(indent=2), encoding="utf-8")

--- a/tests/test_surface_scan_artifacts.py
+++ b/tests/test_surface_scan_artifacts.py
@@ -1,0 +1,47 @@
+"""Tests for surface scan subcommand artifact paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mcts.cli.main import app
+from mcts.output.analysis_dir import ANALYSIS_DIR_NAME
+
+runner = CliRunner()
+
+
+def test_surface_scans_write_distinct_html_and_sarif(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "notes.md").write_text("Agent instructions for testing.\n", encoding="utf-8")
+
+    prompts = runner.invoke(app, ["scan-prompts", str(target)])
+    resources = runner.invoke(app, ["scan-resources", str(target)])
+    instructions = runner.invoke(app, ["scan-instructions", str(target)])
+
+    assert prompts.exit_code == 0, prompts.stdout
+    assert resources.exit_code == 0, resources.stdout
+    assert instructions.exit_code == 0, instructions.stdout
+
+    analysis_dir = tmp_path / ANALYSIS_DIR_NAME
+    expected = (
+        "scan-prompts-report.json",
+        "scan-prompts-report.html",
+        "scan-prompts-report.sarif",
+        "scan-resources-report.json",
+        "scan-resources-report.html",
+        "scan-resources-report.sarif",
+        "scan-instructions-report.json",
+        "scan-instructions-report.html",
+        "scan-instructions-report.sarif",
+    )
+    for name in expected:
+        path = analysis_dir / name
+        assert path.is_file(), f"missing artifact: {name}"
+
+    prompts_html = (analysis_dir / "scan-prompts-report.html").read_text(encoding="utf-8")
+    resources_html = (analysis_dir / "scan-resources-report.html").read_text(encoding="utf-8")
+    assert prompts_html != resources_html


### PR DESCRIPTION
## Summary

- Derive HTML and SARIF sibling paths from each surface scan JSON basename in `persist_scan_artifacts`
- Prevents `scan-prompts`, `scan-resources`, and `scan-instructions` from overwriting the shared `scan-report.html` / `scan-report.sarif` artifacts
- Adds regression coverage for three sequential surface scans retaining distinct outputs

Fixes #220

## Test plan

- [x] `uv run pytest tests/test_surface_scan_artifacts.py -q`
- [x] `uv run ruff check src/mcts/output/artifacts.py tests/test_surface_scan_artifacts.py`
- [ ] Manual: run all three surface subcommands in one directory and confirm three HTML files under `mcts_analysis/`


Made with [Cursor](https://cursor.com)