### PR TITLE
fix(doctor): explain when --deep import checks are skipped (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log when `--pip-audit` is skipped (missing CLI or dependency manifest) and keep CVE findings when the audit runs successfully.
 - Allow `mcts scan --url https://host/mcp` without an explicit TARGET positional argument.
 - Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
+- Explain when `mcts doctor --deep` import checks are skipped (no MCP config or no `-m` module in launch args).
 
 ### Changed
 

--- a/src/mcts/cli/doctor.py
+++ b/src/mcts/cli/doctor.py
@@ -81,10 +81,22 @@ def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> 
         checks.append(("warn", "Entrypoint candidate", "none found"))
         warnings += 1
 
-    if deep and configs:
-        for cfg in configs[:1]:
-            for server_name in sorted(load_servers_dict(cfg))[:2]:
-                _deep_import_check(cfg, server_name, checks)
+    if deep:
+        if not configs:
+            checks.append(("warn", "Deep checks", "skipped — no MCP config found"))
+            warnings += 1
+        else:
+            for cfg in configs[:1]:
+                try:
+                    server_names = sorted(load_servers_dict(cfg))[:2]
+                except ConfigDiscoveryError:
+                    server_names = []
+                if not server_names:
+                    checks.append(("warn", "Deep checks", "skipped — no servers in config"))
+                    warnings += 1
+                    continue
+                for server_name in server_names:
+                    _deep_import_check(cfg, server_name, checks)
 
     if deep:
         warnings += _check_optional_toolchain(checks)
@@ -154,6 +166,13 @@ def _deep_import_check(config_path: Path, server_name: str, checks: list[tuple[s
             module = live.args[idx + 1].split(":")[0]
             break
     if not module:
+        checks.append(
+            (
+                "warn",
+                "Deep checks",
+                f"skipped for {server_name!r} — no -m module in launch args",
+            )
+        )
         return
     cwd = Path(live.cwd or ".")
     result = subprocess.run(

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -1483,7 +1483,10 @@ def doctor(
     ] = Path("."),
     deep: Annotated[
         bool,
-        typer.Option("--deep", help="Run optional import dry-run checks for config servers"),
+        typer.Option(
+            "--deep",
+            help="Run import validation for MCP server modules (requires .mcp.json or other MCP config)",
+        ),
     ] = False,
     json_output: Annotated[
         bool,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -86,3 +86,31 @@ def test_doctor_deep_exits_zero(tmp_path: Path) -> None:
     result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
 
     assert result.exit_code == 0
+
+
+def test_doctor_deep_without_config_shows_skip_message(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Deep checks: skipped — no MCP config found" in result.stdout
+
+
+def test_doctor_deep_without_module_shows_skip_message(tmp_path: Path) -> None:
+    config = tmp_path / ".mcp.json"
+    config.write_text(json.dumps({"mcpServers": {"local": {"command": "python", "args": ["server.py"]}}}))
+
+    result = runner.invoke(app, ["doctor", "--deep", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Deep checks: skipped for 'local' — no -m module in launch args" in result.stdout
+
+
+def test_doctor_deep_json_includes_skip_status(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--deep", "--json", str(tmp_path)])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout.split("Saved")[0].strip())
+    deep_checks = [row for row in payload["checks"] if row["label"] == "Deep checks"]
+    assert deep_checks
+    assert deep_checks[0]["status"] == "warn"
+    assert "skipped" in deep_checks[0]["detail"]


### PR DESCRIPTION
## Summary

- Surface explicit warnings when `mcts doctor --deep` cannot run module import validation
- Covers missing MCP config, empty server list, and servers without a `-m` module in launch args
- JSON doctor output includes the skip status; `--deep` help text documents the prerequisite

Fixes #211

## Test plan

- [x] `uv run pytest tests/test_doctor.py -q`
- [x] `uv run ruff check src/mcts/cli/doctor.py src/mcts/cli/main.py tests/test_doctor.py`
- [ ] Manual: `mcts doctor --deep .` in a repo without `.mcp.json` shows the skip warning