### PR TITLE
fix(cli): print score breakdown when CI min-score gate fails (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Print MCP Surface / Supply Chain / Dependency Hygiene breakdown when `--min-score` or `--ci` gate fails.
 - Validate resolvable live launch configuration before the consent gate on `mcts snapshot` and `mcts fuzz`.
 
 ## [0.1.2] - 2026-06-10

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -163,11 +163,35 @@ def _print_discovery_hints(target: Path) -> None:
         console.print(f"  [dim]{line}[/dim]")
 
 
+def _print_min_score_gate_failure(report, min_score: int) -> None:
+    overall = report.score.overall
+    console.print(f"[red]CI gate failed:[/red] overall score {overall}/100 (minimum {min_score})")
+    breakdown = getattr(report, "score_breakdown", None)
+    if breakdown is None:
+        return
+    buckets = [
+        ("MCP Surface", breakdown.mcp_surface),
+        ("Supply Chain", breakdown.supply_chain),
+        ("Dependency Hygiene", breakdown.dependency_hygiene),
+    ]
+    lowest_label, lowest_score = min(buckets, key=lambda item: item[1])
+    console.print("[yellow]Score breakdown:[/yellow]")
+    for label, score in buckets:
+        suffix = " ← primary failure driver" if label == lowest_label else ""
+        console.print(f"  {label}: {score}/100{suffix}")
+    console.print(f"  Composite: {breakdown.composite}/100")
+    if lowest_score < min_score:
+        console.print(
+            f"[dim]Lowest bucket ({lowest_label}) is below the overall minimum; "
+            "review findings in that area before changing MCP tool code.[/dim]"
+        )
+
+
 def _check_gates(report, config: ScanConfig) -> None:
     if config.fail_on_critical and report.summary.critical > 0:
         raise typer.Exit(code=1)
     if config.min_score is not None and report.score.overall < config.min_score:
-        console.print(f"[red]Score {report.score.overall} is below minimum {config.min_score}[/red]")
+        _print_min_score_gate_failure(report, config.min_score)
         raise typer.Exit(code=1)
     if config.max_critical is not None and report.summary.critical > config.max_critical:
         console.print(
@@ -495,7 +519,10 @@ def scan(
     ] = None,
     ci: Annotated[
         bool,
-        typer.Option("--ci", help="Apply CI gate preset (fail-on-critical, min-score 70)"),
+        typer.Option(
+            "--ci",
+            help="Apply CI gate preset (fail-on-critical, min-score 70) and print score breakdown on failure",
+        ),
     ] = False,
     policy: Annotated[
         Path | None,

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -81,6 +81,12 @@ def test_min_score_gate_fails(example_server_path: Path) -> None:
         ["scan", str(example_server_path), "--min-score", "99", "--no-progress", "--no-save"],
     )
     assert result.exit_code == 1
+    assert "CI gate failed" in result.stdout
+    assert "Score breakdown:" in result.stdout
+    assert "MCP Surface:" in result.stdout
+    assert "Supply Chain:" in result.stdout
+    assert "Dependency Hygiene:" in result.stdout
+    assert "primary failure driver" in result.stdout
 
 
 def test_min_score_gate_passes_on_baseline_server() -> None:


### PR DESCRIPTION
## Summary

- When `--min-score` or `--ci` fails, print MCP Surface, Supply Chain, Dependency Hygiene, and Composite scores before exit
- Highlight the lowest bucket as the primary failure driver so CI logs are not misread as MCP security failures
- No change to scoring math; presentation-only improvement at the gate check

Fixes #204

## Test plan

- [x] `uv run pytest tests/test_sarif.py::test_min_score_gate_fails -q`
- [x] `uv run ruff check src/mcts/cli/main.py tests/test_sarif.py`
- [ ] Manual: `mcts scan . --ci` on a repo with low dependency hygiene score shows breakdown in failure output


Made with [Cursor](https://cursor.com)