### PR TITLE
fix(supply-chain): parse pyproject deps and honor Python lockfiles (#151, #155, #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
 - Suppress misleading OWASP MCP Top 10 coverage-gap meta-findings when zero MCP tools were discovered.
 - Write distinct HTML and SARIF artifacts for `scan-prompts`, `scan-resources`, and `scan-instructions` instead of overwriting `scan-report.html`.
+- Parse `pyproject.toml` dependencies with structured TOML instead of line heuristics so Poetry metadata and tool config are not flagged as unpinned packages (#155, #160).
+- Skip unpinned-range findings for packages pinned in adjacent `poetry.lock`, `uv.lock`, or `Pipfile.lock` (#151).
 
 ### Changed
 

--- a/src/mcts/analyzers/manifest_deps.py
+++ b/src/mcts/analyzers/manifest_deps.py
@@ -1,0 +1,156 @@
+"""Parse Python dependency manifests and lockfiles for supply-chain checks."""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+UNPINNED_PATTERN = re.compile(r"(\^|~|\*|latest|>=|<=|>|<)", re.I)
+_PEP508_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+_SKIP_DEPENDENCY_NAMES = frozenset({"python", "python_version"})
+
+
+@dataclass(frozen=True)
+class DeclaredDependency:
+    name: str
+    spec: str
+    section: str
+
+
+def normalize_package_name(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def is_unpinned_spec(spec: str) -> bool:
+    text = spec.strip()
+    if not text:
+        return False
+    if text.startswith("=="):
+        return False
+    return bool(UNPINNED_PATTERN.search(text))
+
+
+def load_locked_versions(root: Path) -> dict[str, str]:
+    """Return normalized package name -> pinned version from adjacent lockfiles."""
+    locked: dict[str, str] = {}
+    for filename in ("poetry.lock", "uv.lock"):
+        path = root / filename
+        if path.is_file():
+            locked.update(_load_toml_lock_packages(path))
+    pipfile_lock = root / "Pipfile.lock"
+    if pipfile_lock.is_file():
+        locked.update(_load_pipfile_lock(pipfile_lock))
+    return locked
+
+
+def iter_pyproject_dependencies(path: Path) -> list[DeclaredDependency]:
+    """Extract declared Python dependencies from a pyproject.toml file."""
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+
+    deps: list[DeclaredDependency] = []
+    project = data.get("project")
+    if isinstance(project, dict):
+        raw_deps = project.get("dependencies")
+        if isinstance(raw_deps, list):
+            for entry in raw_deps:
+                if isinstance(entry, str):
+                    deps.extend(_dependency_from_pep508(entry, "project.dependencies"))
+
+        optional = project.get("optional-dependencies")
+        if isinstance(optional, dict):
+            for group, entries in optional.items():
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    if isinstance(entry, str):
+                        deps.extend(
+                            _dependency_from_pep508(entry, f"project.optional-dependencies.{group}")
+                        )
+
+    tool = data.get("tool")
+    if isinstance(tool, dict):
+        poetry = tool.get("poetry")
+        if isinstance(poetry, dict):
+            poetry_deps = poetry.get("dependencies")
+            if isinstance(poetry_deps, dict):
+                for name, spec in poetry_deps.items():
+                    if isinstance(name, str) and isinstance(spec, str):
+                        deps.extend(_dependency_from_mapping(name, spec, "tool.poetry.dependencies"))
+
+            groups = poetry.get("group")
+            if isinstance(groups, dict):
+                for group_name, group_cfg in groups.items():
+                    if not isinstance(group_cfg, dict):
+                        continue
+                    group_deps = group_cfg.get("dependencies")
+                    if isinstance(group_deps, dict):
+                        section = f"tool.poetry.group.{group_name}.dependencies"
+                        for name, spec in group_deps.items():
+                            if isinstance(name, str) and isinstance(spec, str):
+                                deps.extend(_dependency_from_mapping(name, spec, section))
+
+    return deps
+
+
+def _dependency_from_pep508(entry: str, section: str) -> list[DeclaredDependency]:
+    text = entry.strip()
+    if not text or text.startswith("#"):
+        return []
+    match = _PEP508_NAME.match(text)
+    if not match:
+        return []
+    name = match.group(1)
+    if normalize_package_name(name) in _SKIP_DEPENDENCY_NAMES:
+        return []
+    return [DeclaredDependency(name=name, spec=text, section=section)]
+
+
+def _dependency_from_mapping(name: str, spec: str, section: str) -> list[DeclaredDependency]:
+    if normalize_package_name(name) in _SKIP_DEPENDENCY_NAMES:
+        return []
+    return [DeclaredDependency(name=name, spec=spec.strip(), section=section)]
+
+
+def _load_toml_lock_packages(path: Path) -> dict[str, str]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+    locked: dict[str, str] = {}
+    packages = data.get("package")
+    if not isinstance(packages, list):
+        return locked
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            locked[normalize_package_name(name)] = version
+    return locked
+
+
+def _load_pipfile_lock(path: Path) -> dict[str, str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    locked: dict[str, str] = {}
+    for section_name, section in data.items():
+        if section_name.startswith("_") or not isinstance(section, dict):
+            continue
+        for name, meta in section.items():
+            if not isinstance(name, str) or not isinstance(meta, dict):
+                continue
+            version = meta.get("version")
+            if isinstance(version, str):
+                locked[normalize_package_name(name)] = version.lstrip("=")
+    return locked

--- a/src/mcts/analyzers/manifest_deps.py
+++ b/src/mcts/analyzers/manifest_deps.py
@@ -69,9 +69,7 @@ def iter_pyproject_dependencies(path: Path) -> list[DeclaredDependency]:
                     continue
                 for entry in entries:
                     if isinstance(entry, str):
-                        deps.extend(
-                            _dependency_from_pep508(entry, f"project.optional-dependencies.{group}")
-                        )
+                        deps.extend(_dependency_from_pep508(entry, f"project.optional-dependencies.{group}"))
 
     tool = data.get("tool")
     if isinstance(tool, dict):

--- a/src/mcts/analyzers/supply_chain.py
+++ b/src/mcts/analyzers/supply_chain.py
@@ -7,11 +7,17 @@ import re
 from pathlib import Path
 
 from mcts.analyzers.base import BaseAnalyzer
+from mcts.analyzers.manifest_deps import (
+    UNPINNED_PATTERN,
+    is_unpinned_spec,
+    iter_pyproject_dependencies,
+    load_locked_versions,
+    normalize_package_name,
+)
 from mcts.core.config import DEFAULT_EXCLUDE_DIRS
 from mcts.mcp.models import MCPServerInfo
 from mcts.reporting.models import Finding, Severity, SourceLocation
 
-UNPINNED_PATTERN = re.compile(r"(\^|~|\*|latest|>=|<=|>|<)", re.I)
 SUSPICIOUS_NPM_SCRIPT = re.compile(r"(postinstall|preinstall|prepare)", re.I)
 DOCKER_FROM = re.compile(r"^\s*FROM\s+(\S+)", re.I | re.M)
 NPM_EXEC = re.compile(r"\b(npx|npm)\s+(install|-g|exec)\b", re.I)
@@ -83,22 +89,28 @@ class SupplyChainAnalyzer(BaseAnalyzer):
     def _scan_pyproject(self, root: Path) -> list[Finding]:
         findings: list[Finding] = []
         for path in _find_files(root, "pyproject.toml"):
-            text = path.read_text(encoding="utf-8", errors="ignore")
-            for line_no, line in enumerate(text.splitlines(), start=1):
-                if UNPINNED_PATTERN.search(line) and any(
-                    token in line for token in ('"', "dependencies", "requires")
-                ):
-                    findings.append(
-                        _finding(
-                            path,
-                            f"supply-unpinned-py-{line_no}",
-                            "Unpinned Python dependency",
-                            line.strip(),
-                            Severity.MEDIUM,
-                            "MCTS-T-1014",
-                            line=line_no,
-                        )
+            manifest_root = path.parent
+            locked = load_locked_versions(manifest_root)
+            for dep in iter_pyproject_dependencies(path):
+                if not is_unpinned_spec(dep.spec):
+                    continue
+                if normalize_package_name(dep.name) in locked:
+                    continue
+                findings.append(
+                    _finding(
+                        path,
+                        f"supply-unpinned-py-{normalize_package_name(dep.name)}",
+                        f"Unpinned Python dependency: {dep.name}",
+                        f"{dep.section}: {dep.name} = {dep.spec!r}",
+                        Severity.MEDIUM,
+                        "MCTS-T-1014",
+                        evidence={
+                            "package": dep.name,
+                            "spec": dep.spec,
+                            "section": dep.section,
+                        },
                     )
+                )
         return findings
 
     def _scan_requirements(self, root: Path) -> list[Finding]:

--- a/tests/test_manifest_deps.py
+++ b/tests/test_manifest_deps.py
@@ -1,0 +1,169 @@
+"""Tests for pyproject dependency parsing and lockfile-aware supply-chain checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcts.analyzers.manifest_deps import (
+    iter_pyproject_dependencies,
+    load_locked_versions,
+    normalize_package_name,
+)
+from mcts.analyzers.supply_chain import SupplyChainAnalyzer
+from mcts.mcp.models import MCPServerInfo
+
+
+def _server() -> MCPServerInfo:
+    return MCPServerInfo(tools=[])
+
+
+def test_iter_pyproject_skips_poetry_metadata_and_tool_config(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry]
+name = "demo"
+description = "Bridge for IFD >= 3.9 environments"
+authors = ["UXE AI Solutions <team@example.com>"]
+
+[tool.pytest.ini_options]
+python_files = "test_*.py"
+python_classes = "Test*"
+
+[tool.ruff]
+line-length = 100
+
+[tool.poetry.dependencies]
+python = "^3.11"
+httpx = "^0.27.0"
+""",
+        encoding="utf-8",
+    )
+    deps = iter_pyproject_dependencies(pyproject)
+    names = {dep.name for dep in deps}
+    assert names == {"httpx"}
+
+
+def test_supply_chain_skips_poetry_metadata_false_positives(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry]
+description = "Supports environments >= 3.9"
+authors = ["Team <team@example.com>"]
+
+[tool.pytest.ini_options]
+python_files = "test_*.py"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+""",
+        encoding="utf-8",
+    )
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    assert not findings
+
+
+def test_supply_chain_flags_unpinned_without_lockfile(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry.dependencies]
+httpx = "^0.27.0"
+fastmcp = ">=1.0"
+""",
+        encoding="utf-8",
+    )
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    titles = {finding.title for finding in findings}
+    assert "Unpinned Python dependency: httpx" in titles
+    assert "Unpinned Python dependency: fastmcp" in titles
+
+
+def test_supply_chain_skips_locked_poetry_dependencies(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry.dependencies]
+httpx = "^0.27.0"
+requests = "^2.31.0"
+""",
+        encoding="utf-8",
+    )
+    lock = tmp_path / "poetry.lock"
+    lock.write_text(
+        """
+[[package]]
+name = "httpx"
+version = "0.27.2"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+""",
+        encoding="utf-8",
+    )
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    assert not findings
+
+
+def test_supply_chain_honors_uv_lock(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = [
+  "httpx>=0.28.0",
+]
+""",
+        encoding="utf-8",
+    )
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        """
+[[package]]
+name = "httpx"
+version = "0.28.1"
+""",
+        encoding="utf-8",
+    )
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    assert not any(f.title.startswith("Unpinned Python dependency") for f in findings)
+
+
+def test_load_locked_versions_from_pipfile_lock(tmp_path: Path) -> None:
+    lock = tmp_path / "Pipfile.lock"
+    lock.write_text(
+        """
+{
+  "default": {
+    "requests": {
+      "version": "==2.31.0"
+    }
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    locked = load_locked_versions(tmp_path)
+    assert locked[normalize_package_name("requests")] == "2.31.0"
+
+
+def test_project_dependencies_parsed(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["pydantic>=2.13.4"]
+""",
+        encoding="utf-8",
+    )
+
+    deps = iter_pyproject_dependencies(pyproject)
+    assert len(deps) == 1
+    assert deps[0].name == "pydantic"


### PR DESCRIPTION
## Summary

- Replace line-heuristic `pyproject.toml` scanning with structured `tomllib` dependency extraction
- Stop flagging Poetry metadata, pytest/ruff/mypy config, and other non-dependency sections as unpinned packages
- Skip unpinned-range findings when the package is pinned in adjacent `poetry.lock`, `uv.lock`, or `Pipfile.lock`

Fixes #151
Fixes #155
Fixes #160

## Test plan

- [x] `uv run pytest tests/test_manifest_deps.py tests/test_phase2.py::test_supply_chain_flags_unpinned_requirements -q`
- [x] `uv run ruff check src/mcts/analyzers/manifest_deps.py src/mcts/analyzers/supply_chain.py tests/test_manifest_deps.py`
- [ ] Manual: scan a Poetry repo with `poetry.lock` — no false MEDIUM findings on metadata or locked deps


Made with [Cursor](https://cursor.com)