### PR TITLE
fix(cli): unify -o and --no-progress across doctor and scan subcommands (#156, #157, #158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
 - Suppress misleading OWASP MCP Top 10 coverage-gap meta-findings when zero MCP tools were discovered.
 - Write distinct HTML and SARIF artifacts for `scan-prompts`, `scan-resources`, and `scan-instructions` instead of overwriting `scan-report.html`.
+- Add `-o` / `--output` to `mcts doctor` and surface scan subcommands for CI artifact paths (#156, #157).
+- Accept `--no-progress` on `readiness`, `fuzz`, `scan-mcp`, and surface scan subcommands for shared CI scripts (#158).
 
 ### Changed
 

--- a/docs/platform/cli.md
+++ b/docs/platform/cli.md
@@ -30,12 +30,14 @@ Read-only preflight checks before your first scan (no live probes).
 ```bash
 mcts doctor .
 mcts doctor /path/to/repo --deep
+mcts doctor . --json -o doctor-report.json
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--deep` | Optional import dry-run for config servers |
-| `--json` | Machine-readable output |
+| `--json` | Machine-readable output to stdout |
+| `--output`, `-o` | Write doctor JSON report (default: `mcts_analysis/doctor-report.json`) |
 
 Exit **0** when checks pass; **1** on failures; **2** on user error.
 
@@ -248,10 +250,12 @@ mcts scan ./server.py --terminal-format by_severity \
 Targeted scans without passing `--surfaces`:
 
 ```bash
-mcts scan-prompts <target> [--snapshot path.json]
-mcts scan-resources <target> [--snapshot path.json] [--resource-mime text/plain]
-mcts scan-instructions <target> [--snapshot path.json]
+mcts scan-prompts <target> [-o report.json] [--no-progress] [--snapshot path.json]
+mcts scan-resources <target> [-o report.json] [--no-progress] [--snapshot path.json] [--resource-mime text/plain]
+mcts scan-instructions <target> [-o report.json] [--no-progress] [--snapshot path.json]
 ```
+
+Each subcommand writes matching HTML and SARIF siblings derived from the JSON basename (for example `scan-prompts-report.json` → `.html` / `.sarif`).
 
 For agent repos with prompts in markdown (not MCP `prompts/list`), repository discovery is enabled by default on static scans:
 

--- a/src/mcts/cli/doctor.py
+++ b/src/mcts/cli/doctor.py
@@ -33,7 +33,13 @@ _OPTIONAL_CLI_CHECKS = (
 )
 
 
-def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> int:
+def run_doctor(
+    path: Path,
+    *,
+    deep: bool = False,
+    json_output: bool = False,
+    output: Path | None = None,
+) -> int:
     """Run read-only preflight checks. Returns exit code (0 ok, 1 failures, 2 user error)."""
     root = path.expanduser().resolve()
     if not root.exists():
@@ -89,23 +95,26 @@ def run_doctor(path: Path, *, deep: bool = False, json_output: bool = False) -> 
     if deep:
         warnings += _check_optional_toolchain(checks)
 
-    if json_output:
+    payload = {
+        "path": str(root),
+        "checks": [{"status": s, "label": label, "detail": d} for s, label, d in checks],
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+    if json_output or output is not None:
         import json
 
         from mcts.output.analysis_dir import resolve_output_path
 
-        payload = {
-            "path": str(root),
-            "checks": [{"status": s, "label": label, "detail": d} for s, label, d in checks],
-            "failures": failures,
-            "warnings": warnings,
-        }
+        output_path = resolve_output_path(output, "doctor-report.json")
         text = json.dumps(payload, indent=2)
-        output_path = resolve_output_path(None, "doctor-report.json")
         output_path.write_text(text, encoding="utf-8")
-        console.print_json(text)
+        if json_output:
+            console.print_json(text)
         console.print(f"[green]Saved[/green] {output_path}")
-    else:
+
+    if not json_output:
         console.print(f"[bold]mcts doctor[/bold] {path}\n")
         for status, label, detail in checks:
             icon = {"pass": "[green]✓[/green]", "warn": "[yellow]⚠[/yellow]", "fail": "[red]✗[/red]"}[status]

--- a/src/mcts/cli/main.py
+++ b/src/mcts/cli/main.py
@@ -1205,6 +1205,10 @@ def fuzz(
         Path | None,
         typer.Option("--output", "-o", help="Write fuzz findings JSON"),
     ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
     understand_live_risk: Annotated[
         bool,
         typer.Option(
@@ -1285,6 +1289,7 @@ def fuzz(
         remote_transport=transport,
         bearer_token=bearer_token,
         remote_headers=remote_headers,
+        no_progress=no_progress,
     )
     _validate_live_launch(fuzz_config)
 
@@ -1352,6 +1357,10 @@ def _parse_headers(header: list[str] | None) -> dict[str, str]:
 def readiness(
     target: Annotated[Path, typer.Argument(help="MCP server path or repo")],
     output: Annotated[Path | None, typer.Option("--output", "-o")] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
     enable_opa: Annotated[
         bool,
         typer.Option("--opa", help="Enable optional OPA Rego policy checks"),
@@ -1366,7 +1375,12 @@ def readiness(
 
     from mcts.readiness.runner import run_readiness
 
-    config = ScanConfig(target=target, readiness_opa=enable_opa, readiness_llm=enable_llm)
+    config = ScanConfig(
+        target=target,
+        readiness_opa=enable_opa,
+        readiness_llm=enable_llm,
+        no_progress=no_progress,
+    )
     report = run_readiness(config)
     console.print(
         f"[bold]Readiness[/bold] — score {report.readiness_score}/100, "
@@ -1425,23 +1439,40 @@ def _surface_scan(
     snapshot: Path | None = None,
     *,
     artifact_name: str,
+    output: Path | None = None,
+    no_progress: bool = False,
+    resource_mime_allowlist: list[str] | None = None,
 ) -> None:
     """Run a scan limited to specific MCP surfaces."""
+    from mcts.ui.theme import ThemeName, get_theme
+
     config = ScanConfig(
         target=target,
         surfaces=surfaces,
         snapshot_path=snapshot,
         surface_scoped_analyzers=True,
         discover_instructions=True,
+        resource_mime_allowlist=resource_mime_allowlist or [],
+        no_progress=no_progress,
     )
-    report = Scanner(config).run()
+
+    def _run_scan():
+        return Scanner(config).run()
+
+    theme = get_theme(ThemeName.MINIMAL.value)
+    report = run_with_progress(
+        _run_scan,
+        theme=theme,
+        console=console,
+        enabled=not no_progress,
+    )
     console.print(f"[bold]MCTS[/bold] — {len(report.findings)} finding(s) on surfaces: {', '.join(surfaces)}")
     for finding in report.findings[:15]:
         console.print(f"  [{finding.severity.value}] {finding.title}")
 
     json_path, html_path, sarif_path = persist_scan_artifacts(
         report,
-        json_path=resolve_output_path(None, artifact_name),
+        json_path=resolve_output_path(output, artifact_name),
     )
     console.print(f"[green]Saved[/green] {json_path}, {html_path}, {sarif_path}")
 
@@ -1453,9 +1484,24 @@ def scan_prompts(
         Path | None,
         typer.Option("--snapshot", help="Static JSON snapshot with prompts"),
     ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write scan JSON report"),
+    ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
 ) -> None:
     """Scan prompts and server instructions only."""
-    _surface_scan(target, ["prompt", "instruction"], snapshot, artifact_name="scan-prompts-report.json")
+    _surface_scan(
+        target,
+        ["prompt", "instruction"],
+        snapshot,
+        artifact_name="scan-prompts-report.json",
+        output=output,
+        no_progress=no_progress,
+    )
 
 
 @app.command("scan-resources")
@@ -1469,25 +1515,26 @@ def scan_resources(
         str | None,
         typer.Option("--resource-mime", help="Comma-separated MIME allowlist"),
     ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write scan JSON report"),
+    ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
 ) -> None:
     """Scan MCP resources only."""
     mime_list = [p.strip() for p in resource_mime.split(",") if p.strip()] if resource_mime else []
-    config = ScanConfig(
-        target=target,
-        surfaces=["resource"],
-        snapshot_path=snapshot,
+    _surface_scan(
+        target,
+        ["resource"],
+        snapshot,
+        artifact_name="scan-resources-report.json",
+        output=output,
+        no_progress=no_progress,
         resource_mime_allowlist=mime_list,
     )
-    report = Scanner(config).run()
-    console.print(f"[bold]MCTS[/bold] — {len(report.findings)} resource finding(s)")
-    for finding in report.findings[:15]:
-        console.print(f"  [{finding.severity.value}] {finding.title}")
-
-    json_path, html_path, sarif_path = persist_scan_artifacts(
-        report,
-        json_path=resolve_output_path(None, "scan-resources-report.json"),
-    )
-    console.print(f"[green]Saved[/green] {json_path}, {html_path}, {sarif_path}")
 
 
 @app.command("scan-instructions")
@@ -1497,9 +1544,24 @@ def scan_instructions(
         Path | None,
         typer.Option("--snapshot", help="Static JSON snapshot with instructions"),
     ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write scan JSON report"),
+    ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Skip pre-report progress animation"),
+    ] = False,
 ) -> None:
     """Scan server instructions only."""
-    _surface_scan(target, ["instruction"], snapshot, artifact_name="scan-instructions-report.json")
+    _surface_scan(
+        target,
+        ["instruction"],
+        snapshot,
+        artifact_name="scan-instructions-report.json",
+        output=output,
+        no_progress=no_progress,
+    )
 
 
 @app.command()
@@ -1512,6 +1574,14 @@ def doctor(
         bool,
         typer.Option("--deep", help="Run optional import dry-run checks for config servers"),
     ] = False,
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help=f"Write doctor JSON report (default: {ANALYSIS_DIR_NAME}/doctor-report.json)",
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Emit machine-readable JSON"),
@@ -1520,7 +1590,7 @@ def doctor(
     """Preflight checks before your first scan (no live probes)."""
     from mcts.cli.doctor import run_doctor
 
-    code = run_doctor(path, deep=deep, json_output=json_output)
+    code = run_doctor(path, deep=deep, json_output=json_output, output=output)
     if code:
         raise typer.Exit(code=code)
 
@@ -1641,12 +1711,17 @@ def scan_mcp(
         Path | None,
         typer.Option("--output", "-o", help="Write manifest probe JSON"),
     ] = None,
+    no_progress: Annotated[
+        bool,
+        typer.Option("--no-progress", help="Accepted for CI script parity (no animation today)"),
+    ] = False,
     understand_live_risk: Annotated[
         bool,
         typer.Option("--i-understand-live-risk", help="Consent to live remote probing"),
     ] = False,
 ) -> None:
     """Pre-connect remote MCP manifest probe (tools/list metadata)."""
+    _ = no_progress
     import json
 
     from mcts.probe.consent import live_consent_granted

--- a/tests/test_cli_output_parity.py
+++ b/tests/test_cli_output_parity.py
@@ -1,0 +1,60 @@
+"""Tests for unified -o / --no-progress flags on CLI subcommands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mcts.cli.main import app
+from mcts.output.analysis_dir import ANALYSIS_DIR_NAME
+
+runner = CliRunner()
+
+
+def test_doctor_accepts_output_flag(tmp_path: Path) -> None:
+    output = tmp_path / "doctor.json"
+    result = runner.invoke(app, ["doctor", str(tmp_path), "-o", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+    assert output.is_file()
+    assert '"checks"' in output.read_text(encoding="utf-8")
+
+
+def test_readiness_accepts_no_progress(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["readiness", str(tmp_path), "--no-progress"])
+
+    assert result.exit_code in {0, 1}
+    assert "No such option" not in result.stdout
+
+
+def test_fuzz_accepts_no_progress_flag() -> None:
+    result = runner.invoke(
+        app,
+        ["fuzz", ".", "--i-understand-live-risk", "--no-progress"],
+    )
+
+    assert "No such option: --no-progress" not in result.stdout
+
+
+def test_scan_mcp_accepts_no_progress_flag() -> None:
+    result = runner.invoke(app, ["scan-mcp", "--no-progress", "https://example.com/mcp"])
+
+    assert "No such option: --no-progress" not in result.stdout
+
+
+def test_scan_prompts_output_and_no_progress(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "notes.md").write_text("Instructions for testing.\n", encoding="utf-8")
+    output = tmp_path / "prompts.json"
+
+    result = runner.invoke(
+        app,
+        ["scan-prompts", str(target), "-o", str(output), "--no-progress"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert output.is_file()
+    assert (tmp_path / ANALYSIS_DIR_NAME / "prompts.json").is_file() or output.is_file()


### PR DESCRIPTION
## Summary

- Add `-o` / `--output` to `mcts doctor` and surface scan subcommands (`scan-prompts`, `scan-resources`, `scan-instructions`)
- Add `--no-progress` to `readiness`, `fuzz`, `scan-mcp`, and surface scan subcommands for shared CI scripts
- Refactor `scan-resources` through `_surface_scan` so output and progress behavior match the other surface commands

Fixes #156
Fixes #157
Fixes #158

Partial progress toward unified output API (#216).

## Test plan

- [x] `uv run pytest tests/test_cli_output_parity.py tests/test_doctor.py tests/test_surface_scan_artifacts.py -q`
- [x] `uv run ruff check src/mcts/cli/main.py src/mcts/cli/doctor.py tests/test_cli_output_parity.py`
- [ ] Manual: `mcts doctor . -o /tmp/doctor.json` writes JSON without Typer error
- [ ] Manual: `mcts readiness . --no-progress` accepts flag


Made with [Cursor](https://cursor.com)