### PR TITLE
docs(vet): document pypi:package==version spec syntax (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fail `mcts readiness` when zero MCP tools are discovered instead of reporting production-ready with `tools_checked: 0`.
 - Suppress misleading OWASP MCP Top 10 coverage-gap meta-findings when zero MCP tools were discovered.
 - Write distinct HTML and SARIF artifacts for `scan-prompts`, `scan-resources`, and `scan-instructions` instead of overwriting `scan-report.html`.
+- Document PEP 508 `pypi:package==version` syntax for `mcts vet` alongside existing `@` pin form.
 
 ### Changed
 

--- a/docs/platform/cli.md
+++ b/docs/platform/cli.md
@@ -336,10 +336,13 @@ Pre-install vetting for PyPI, npm, and OCI package references before adding them
 
 ```bash
 mcts vet pypi:requests@2.31.0
+mcts vet pypi:fastapi==0.136.3
 mcts vet npm:@modelcontextprotocol/sdk
 mcts vet oci:ghcr.io/org/mcp-server:1.0.0
 mcts vet pypi:fastmcp --json -o vet-report.json
 ```
+
+PyPI specs accept npm-style `@` pins or standard PEP 508 `==` pins after the `pypi:` prefix.
 
 | Flag | Default | Description |
 |------|---------|-------------|


### PR DESCRIPTION
## Summary

- Document PEP 508 `pypi:package==version` syntax alongside existing `pypi:package@version` in CLI docs
- Parser and tests for `==` pins already exist on `main`; this closes the documentation gap

Fixes #159

## Test plan

- [x] Docs-only change
- [ ] Verify `mcts vet pypi:fastapi==0.136.3` works on main (parser regression covered by `tests/test_vet.py`)


Made with [Cursor](https://cursor.com)