### PR TITLE
fix(discovery): exclude docs/prompts from default instruction discovery (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `-o` / `--output` to `mcts doctor` and surface scan subcommands for CI artifact paths (#156, #157).
 - Accept `--no-progress` on `readiness`, `fuzz`, `scan-mcp`, and surface scan subcommands for shared CI scripts (#158).
 - Explain when `mcts doctor --deep` import checks are skipped (no MCP config or no `-m` module in launch args).
+- Exclude design prompt markdown under `docs/prompts/` from default instruction discovery (#162).
 
 ### Changed
 

--- a/src/mcts/discovery/instruction_files.py
+++ b/src/mcts/discovery/instruction_files.py
@@ -19,6 +19,12 @@ DEFAULT_INSTRUCTION_GLOBS: tuple[str, ...] = (
     "**/INSTRUCTIONS.md",
 )
 
+DEFAULT_INSTRUCTION_SKIP_PREFIXES: tuple[str, ...] = (
+    "docs/prompts/",
+    "doc/prompts/",
+    "design/",
+)
+
 DEFAULT_SKILLS_DIR_NAMES: tuple[str, ...] = (
     "skills",
     "agent/skills",
@@ -207,6 +213,9 @@ def _path_allowed(config: ScanConfig, path: Path, target: ScanTarget) -> bool:
         rel_str = str(path)
 
     if any(part in config.exclude_dirs for part in path.parts):
+        return False
+    rel_normalized = rel_str.replace("\\", "/").lower()
+    if any(rel_normalized.startswith(prefix) for prefix in DEFAULT_INSTRUCTION_SKIP_PREFIXES):
         return False
     return not (config.exclude_globs and any(fnmatch(rel_str, g) for g in config.exclude_globs))
 

--- a/tests/test_instruction_discovery.py
+++ b/tests/test_instruction_discovery.py
@@ -144,6 +144,41 @@ def test_explicit_instruction_file(tmp_path: Path) -> None:
     assert info.prompts[0].source_file == str(prompt.resolve())
 
 
+def test_docs_prompts_excluded_from_default_discovery(tmp_path: Path) -> None:
+    design = tmp_path / "docs" / "prompts"
+    design.mkdir(parents=True)
+    design_file = design / "narrow-confidence-dimensions-prompt.md"
+    design_file.write_text(
+        "# SDD: Narrow Confidence Dimensions\n"
+        "System prompt draft for classifier. You must always call the tool...\n"
+    )
+    runtime = tmp_path / "prompts"
+    runtime.mkdir(parents=True)
+    (runtime / "greeting_prompt.md").write_text("Hello user.\n")
+
+    config = ScanConfig(target=tmp_path, discover_instructions=True)
+    info = discover_instruction_surfaces(config)
+
+    discovered = {p.source_file for p in info.prompts}
+    assert str(design_file.resolve()) not in discovered
+    assert any(str((runtime / "greeting_prompt.md").resolve()) == path for path in discovered)
+
+
+def test_explicit_instruction_file_in_docs_prompts_still_included(tmp_path: Path) -> None:
+    design = tmp_path / "docs" / "prompts" / "review-prompt.md"
+    design.parent.mkdir(parents=True)
+    design.write_text("Explicit design prompt for audit.\n")
+
+    config = ScanConfig(
+        target=tmp_path,
+        discover_instructions=False,
+        instruction_files=[design],
+    )
+    info = discover_instruction_surfaces(config)
+    assert len(info.prompts) == 1
+    assert info.prompts[0].source_file == str(design.resolve())
+
+
 def test_discover_skills_from_repo_path(tmp_path: Path, monkeypatch) -> None:
     skill = tmp_path / "skills" / "deploy"
     skill.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Skip `docs/prompts/`, `doc/prompts/`, and `design/` paths during default instruction discovery
- Preserve runtime prompts under other directories (e.g. `prompts/`)
- Allow opt-in audits via `--instruction-file` for design docs

## Test plan
- [x] `pytest tests/test_instruction_discovery.py`
- [x] `docs/prompts/*.md` not discovered by default
- [x] Explicit `--instruction-file docs/prompts/...` still included


Made with [Cursor](https://cursor.com)