### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-16
+
 ### Added
 
-- **Attack graph v3 rollout (Phase 3a/3b)** — default `attack_graph_version=3`; YAML template matcher replaces `AttackChainAnalyzer`; 12 chain templates including `SSRF_RESOURCE`, `ENV_SAMPLING`, `GIT_UNSCOPED`, `PROMPT_BYPASS`, `ELICIT_PHISH`, `TOCTOU_READ`, `READ_EXEC`, `CRED_THEFT`; capability overlap fallbacks; dashboard v3 paths + SARIF `mcts/attackPathExplanation`; R-23 `ELICIT_PHISH` regression fixture + `tests/scoring/test_phase_3b_templates.py`
+- **Attack graph v3 rollout (Phase 3a/3b)** — default `attack_graph_version=3`; YAML template matcher replaces `AttackChainAnalyzer`; 12 chain templates including `SSRF_RESOURCE`, `ENV_SAMPLING`, `GIT_UNSCOPED`, `PROMPT_BYPASS`, `ELICIT_PHISH`, `TOCTOU_READ`, `READ_EXEC`, `CRED_THEFT`; capability overlap fallbacks; dashboard v3 paths + SARIF `mcts/attackPathExplanation`; R-23–R-25 regression fixtures + `tests/scoring/test_phase_3b_templates.py`
 - **Fact provenance metrics** — `fact_coverage()` reports `native_pct` / `silver_pct`; dashboard exposes `fact_provenance`; CI gates via `check_ttu_baseline.py` + corpus `--check-only`
 - **Scoring corpus** — `single_tool_overlap` fixture under enforce; Spearman calibration validates without mutating fixtures in CI
 - **Taxonomy display** — MCTS-T-1005 renamed to “Capability Overlap & Attack Paths” (ID unchanged)

--- a/docs/more/feature-expansion-plan.md
+++ b/docs/more/feature-expansion-plan.md
@@ -31,7 +31,7 @@ This is the **detailed implementation guide** for evolving MCTS from an alpha sc
 | **Orchestration** | `core/scanner.py`, `core/config.py` | 20+ analyzers → compliance → scoring → `ScanReport` |
 | **Discovery** | `discovery/*`, `mcp/client.py` | Multi-file Python + TypeScript static discovery; live stdio + HTTP/SSE merge |
 | **Analyzers** | `analyzers/*.py` | Metadata, SAST, 20+ runtime sub-detectors, Sigma, OAuth, supply chain |
-| **Attack chains** | `attack_chains.py` | Capability-graph BFS on per-tool profiles |
+| **Attack graph v3** | `scoring/attack_graph_builder.py`, `scoring/templates/` | YAML template matcher + `GraphBuilder`; 12 chain templates; capability overlap fallbacks |
 | **Scoring** | `scoring/engine.py`, `engine_v2.py`, `graph.py`, `chains.py` | Legacy exponential + v2 multi-factor (`absolute_risk`), corpus calibration, dual default `both` |
 | **Compliance** | `compliance/checks.py` | OWASP LLM meta-findings |
 | **CLI** | `cli/main.py` | `scan`, `report`, `inventory`, `fuzz`, `readiness`, `serve`, `vet`, `pentest`, `doctor`, `snapshot`, `scan-mcp`; `mcts-mcp` server mode |
@@ -196,7 +196,7 @@ Fix structural limits before adding features.
 
 **JailbreakAnalyzer:** Weighted manipulation surface (tool count, executes_commands, missing schema, chain edges).
 
-**AttackChainAnalyzer:** Build directed graph from `CapabilityProfile`; BFS for critical paths; store in `ScanReport.attack_graph`.
+**Attack graph v3 (`GraphBuilder`):** Merge producer edges, apply policy edges, match YAML chain templates (read→exfil, SSRF resource staging, URL elicitation, etc.); store paths on `ScanReport.attack_graph`. Legacy capability-overlap findings remain as trust-capped fallbacks via `capability_overlap.py`.
 
 ---
 

--- a/scripts/run_regression.py
+++ b/scripts/run_regression.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Phase 1–2 security regression runner (R-01–R-23)."""
+"""Phase 1–2 security regression runner (R-01–R-25)."""
 
 from __future__ import annotations
 
@@ -114,6 +114,8 @@ def main() -> int:
         "R-20-git-readme",
         "R-22-streamable-get-env",
         "R-23-elicitation-phish",
+        "R-24-read-exec",
+        "R-25-cred-theft",
         "MCTS-T-monorepo-servers",
     ]
 

--- a/src/mcts/__init__.py
+++ b/src/mcts/__init__.py
@@ -1,6 +1,6 @@
 """MCTS (Model Context Threat Scanner) — security analysis for MCP servers."""
 
-__version__ = "0.1.4"
+__version__ = "0.3.0"
 
 from mcts.core.config import ScanConfig
 from mcts.core.scanner import Scanner

--- a/tests/fixtures/monorepo-mini/src/chain-stubs/cred_theft.py
+++ b/tests/fixtures/monorepo-mini/src/chain-stubs/cred_theft.py
@@ -1,0 +1,26 @@
+"""Minimal read→credential→egress chain stub for CRED_THEFT template regression."""
+
+from pathlib import Path
+
+
+def create_app():
+    mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
+
+    @mcp.tool()
+    def read_file(path: str) -> str:
+        """Read any file from the filesystem by path."""
+        return Path(path).read_text()
+
+    @mcp.tool()
+    def get_env(name: str) -> str:
+        """Return environment variable values including OPENAI_API_KEY."""
+        import os
+
+        return os.environ.get(name, "")
+
+    @mcp.tool()
+    def send_webhook(url: str, data: str) -> str:
+        """POST data to an external webhook URL."""
+        return f"sent to {url}"
+
+    return mcp

--- a/tests/fixtures/monorepo-mini/src/chain-stubs/read_exec.py
+++ b/tests/fixtures/monorepo-mini/src/chain-stubs/read_exec.py
@@ -1,0 +1,21 @@
+"""Minimal read→exec chain stub for READ_EXEC template regression."""
+
+from pathlib import Path
+
+
+def create_app():
+    mcp = type("MCP", (), {"tool": staticmethod(lambda **kw: lambda f: f)})()
+
+    @mcp.tool()
+    def read_file(path: str) -> str:
+        """Read any file from the filesystem by path."""
+        return Path(path).read_text()
+
+    @mcp.tool()
+    def run_shell(command: str) -> str:
+        """Execute arbitrary shell commands on the host."""
+        import subprocess
+
+        return subprocess.check_output(command, shell=True, text=True)
+
+    return mcp

--- a/tests/fixtures/regression/R-24-read-exec/expected.json
+++ b/tests/fixtures/regression/R-24-read-exec/expected.json
@@ -1,0 +1,5 @@
+{
+  "servers_path": "src/chain-stubs/read_exec.py",
+  "package_depth": "full",
+  "note": "R-24 — read_file + run_shell enables READ_EXEC chain template"
+}

--- a/tests/fixtures/regression/R-25-cred-theft/expected.json
+++ b/tests/fixtures/regression/R-25-cred-theft/expected.json
@@ -1,0 +1,5 @@
+{
+  "servers_path": "src/chain-stubs/cred_theft.py",
+  "package_depth": "full",
+  "note": "R-25 — read + get_env + send_webhook enables CRED_THEFT chain template"
+}

--- a/tests/scoring/test_phase_3b_templates.py
+++ b/tests/scoring/test_phase_3b_templates.py
@@ -72,3 +72,19 @@ def test_elicit_phish_r23_fixture() -> None:
     report = Scanner(ScanConfig(target=str(target), surface_depth="full")).run()
     matched = set(report.attack_graph.get("templates_matched") or [])
     assert "ELICIT_PHISH" in matched
+
+
+def test_read_exec_r24_fixture() -> None:
+    spec = json.loads((REGRESSION / "R-24-read-exec" / "expected.json").read_text())
+    target = MONOREPO_MINI / spec["servers_path"]
+    report = Scanner(ScanConfig(target=str(target), surface_depth="full")).run()
+    matched = set(report.attack_graph.get("templates_matched") or [])
+    assert "READ_EXEC" in matched
+
+
+def test_cred_theft_r25_fixture() -> None:
+    spec = json.loads((REGRESSION / "R-25-cred-theft" / "expected.json").read_text())
+    target = MONOREPO_MINI / spec["servers_path"]
+    report = Scanner(ScanConfig(target=str(target), surface_depth="full")).run()
+    matched = set(report.attack_graph.get("templates_matched") or [])
+    assert "CRED_THEFT" in matched

--- a/tests/test_attack_graph_v3_scanner.py
+++ b/tests/test_attack_graph_v3_scanner.py
@@ -25,10 +25,14 @@ PHASE_3B_TEMPLATE_FIXTURES = {
     "R-15-gzip-resource": "SSRF_RESOURCE",
     "R-02-dual-fetch": "PROMPT_BYPASS",
     "R-04-git-scoping": "GIT_UNSCOPED",
+    "R-05-git-log": "GIT_UNSCOPED",
+    "R-20-git-readme": "GIT_UNSCOPED",
     "R-09-toctou-test": "TOCTOU_READ",
     "R-10-symlink-listing": "TOCTOU_READ",
     "R-07-get-env": "ENV_SAMPLING",
     "R-23-elicitation-phish": "ELICIT_PHISH",
+    "R-24-read-exec": "READ_EXEC",
+    "R-25-cred-theft": "CRED_THEFT",
 }
 
 


### PR DESCRIPTION
## Summary
- Bump version to **0.3.0** (`src/mcts/__init__.py`)
- Cut CHANGELOG `[Unreleased]` → `[0.3.0] - 2026-06-16`
- Add R-24 (`READ_EXEC`) and R-25 (`CRED_THEFT`) monorepo-mini regression fixtures
- Parametrize R-05 / R-20 for `GIT_UNSCOPED`; update `feature-expansion-plan.md` for GraphBuilder

After merge, tag `v0.3.0` to trigger PyPI + GitHub release workflow.

## Test plan
- [x] `uv run pytest tests/scoring/test_phase_3b_templates.py tests/test_attack_graph_v3_scanner.py::test_phase_3b_template_matches_regression_fixture` — 16 passed
- [x] `uv run python scripts/run_regression.py --servers-root tests/fixtures/monorepo-mini` — R-01–R-25 pass