### PR TITLE
fix: ignore loopback URLs in data leakage findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ignore loopback development URLs in data-leakage findings while retaining detection for non-loopback internal hosts (#194).
 - **ELICIT_PHISH matching** — client-capability `TRIGGERS` edges use `trust_boundary` layer; path enumeration terminates at dead-end capability nodes
 - **Validator hardening** — removed standalone `evidence.hop_count` and `evidence.path` proven-path bypasses; chain level matches associated graph path
 - **Auxiliary trust explicit parity** — vet/fuzz/inventory/readiness/pentest set `findings_trust_mode_explicit` when `--findings-trust-mode` is passed; API readiness adds `ignore_policy` + explicit flag

--- a/src/mcts/analyzers/data_leakage.py
+++ b/src/mcts/analyzers/data_leakage.py
@@ -27,7 +27,7 @@ SECRET_PATTERNS: list[tuple[str, re.Pattern[str], Severity]] = [
     ("Database URL", re.compile(r"(?i)(postgres|mysql|mongodb)://\S+"), Severity.HIGH),
     (
         "Internal URL",
-        re.compile(r"https?://(?:localhost|127\.0\.0\.1|internal|\.local)\S*"),
+        re.compile(r"https?://(?:internal|\.local)\S*", re.IGNORECASE),
         Severity.MEDIUM,
     ),
 ]

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -29,7 +29,7 @@ def test_data_leakage_scans_source_files(example_server_path: Path) -> None:
     assert source_findings or any(f.analyzer == "data_leakage" for f in report.findings)
 
 
-def test_data_leakage_ignores_loopback_urls_in_log_messages() -> None:
+def test_data_leakage_ignores_loopback_urls() -> None:
     server = MCPServerInfo(
         name="perseus",
         source_files={
@@ -46,9 +46,31 @@ def test_data_leakage_ignores_loopback_urls_in_log_messages() -> None:
 
     findings = DataLeakageAnalyzer().analyze(server)
 
-    assert len(findings) == 1
-    assert findings[0].location
-    assert findings[0].location.line == 4
+    assert not findings
+
+
+def test_data_leakage_flags_non_loopback_internal_urls() -> None:
+    server = MCPServerInfo(
+        name="sso-config",
+        source_files={
+            "config.py": "\n".join(
+                [
+                    "SSO_ENDPOINTS = {",
+                    "    'local': 'http://localhost:8080/sso',",
+                    "    'loopback': 'http://127.0.0.1:8080/sso',",
+                    "    'stage': 'https://stage.example.com/sso',",
+                    "}",
+                    "PROD_SSO = 'https://internal.example.com/sso'",
+                    "SERVICE_SSO = 'http://internal-service:8080/sso'",
+                ]
+            )
+        },
+    )
+
+    findings = DataLeakageAnalyzer().analyze(server)
+
+    assert len(findings) == 2
+    assert [finding.location.line if finding.location else None for finding in findings] == [6, 7]
 
 
 def test_docker_dedupe_dockerfile_and_containerfile(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Stop reporting localhost and 127.0.0.1 development URLs as internal URL leakage.
- Preserve detection for non-loopback internal hosts, including `internal-*` names.
- Add regression coverage for loopback and production-style internal URLs.

Closes #194

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [ ] `uv run pytest`
- [ ] `uv run ruff check src tests`
- [ ] Manual CLI reproduction for #194

## Checklist

- [x] CHANGELOG.md updated
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [x] No CLI or report schema documentation change required