### PR TITLE
fix(analyzers): broaden and redact secret detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Broaden secret detection for AI/provider tokens, modern GitHub tokens, package registry tokens, private keys, and common JSON/YAML assignments; redact matched credentials from finding evidence.
+- Broaden secret detection for AI/provider tokens, modern GitHub tokens, package registry tokens, private keys, and common JSON/YAML assignments; redact matched credentials from finding evidence and ignore explicit copy-paste placeholders.
 
 ## [0.1.4] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Broaden secret detection for AI/provider tokens, modern GitHub tokens, package registry tokens, private keys, and common JSON/YAML assignments; redact matched credentials from finding evidence.
+
 ## [0.1.4] - 2026-06-12
 
 ### Security

--- a/src/mcts/analyzers/data_leakage.py
+++ b/src/mcts/analyzers/data_leakage.py
@@ -32,10 +32,17 @@ SECRET_PATTERNS: list[tuple[str, re.Pattern[str], Severity]] = [
     ),
     ("JWT", re.compile(r"eyJ[a-zA-Z0-9\-_]+\.eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+"), Severity.HIGH),
     (
+        "Bearer Token",
+        re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{12,}"),
+        Severity.HIGH,
+    ),
+    (
         "Generic Secret Assignment",
         re.compile(
-            r"(?i)[\"']?(?:api[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|"
-            r"database[_-]?password|db[_-]?password|password|secret|token)[\"']?\s*[:=]\s*"
+            r"(?i)[\"']?(?:api[_-]?(?:key|token)|client[_-]?secret|access[_-]?token|"
+            r"auth[_-]?token|refresh[_-]?token|private[_-]?key|webhook[_-]?secret|"
+            r"signing[_-]?secret|database[_-]?password|db[_-]?password|password|secret|token)"
+            r"[\"']?\s*[:=]\s*"
             r"[\"']?[A-Za-z0-9_./+=:@-]{8,}"
         ),
         Severity.HIGH,

--- a/src/mcts/analyzers/data_leakage.py
+++ b/src/mcts/analyzers/data_leakage.py
@@ -75,6 +75,10 @@ SECRET_ENV_VARS = (
 
 HIDDEN_CHAR_PATTERN = re.compile(r"[\u200b-\u200f\ufeff\u202a-\u202e]")
 
+TEMPLATE_SECRET_PATTERN = re.compile(
+    r"(?i)\b(?:YOUR_(?:API_)?KEY|REPLACE_WITH(?:_[A-Z0-9]+)*|INSERT_(?:API_)?KEY(?:_HERE)?)\b"
+)
+
 LOGGING_CALL_PATTERN = re.compile(
     r"""
     ^\s*
@@ -100,6 +104,11 @@ def _redact_secrets(line: str) -> str:
     for _, pattern, _ in SECRET_PATTERNS:
         redacted = pattern.sub("[REDACTED]", redacted)
     return redacted.strip()[:120]
+
+
+def _is_template_secret(match: re.Match[str]) -> bool:
+    """Recognize explicit copy-paste placeholders without hiding nearby credentials."""
+    return bool(TEMPLATE_SECRET_PATTERN.search(match.group(0)))
 
 
 class DataLeakageAnalyzer(BaseAnalyzer):
@@ -162,6 +171,8 @@ class DataLeakageAnalyzer(BaseAnalyzer):
                 for label, pattern, severity in SECRET_PATTERNS:
                     match = pattern.search(line)
                     if not match:
+                        continue
+                    if _is_template_secret(match):
                         continue
                     if label == "Internal URL" and _is_logging_statement(line):
                         continue

--- a/src/mcts/analyzers/data_leakage.py
+++ b/src/mcts/analyzers/data_leakage.py
@@ -11,16 +11,33 @@ from mcts.scoring.evidence_tags import tag_data_leakage_finding
 
 SECRET_PATTERNS: list[tuple[str, re.Pattern[str], Severity]] = [
     ("OpenAI API Key", re.compile(r"sk-[A-Za-z0-9]{20,}"), Severity.CRITICAL),
+    ("Anthropic API Key", re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), Severity.CRITICAL),
+    ("Hugging Face Token", re.compile(r"hf_[A-Za-z0-9]{20,}"), Severity.CRITICAL),
     ("AWS Access Key", re.compile(r"AKIA[0-9A-Z]{16}"), Severity.CRITICAL),
     ("Google API Key", re.compile(r"AIza[0-9A-Za-z\-_]{35}"), Severity.CRITICAL),
     ("Google OAuth Token", re.compile(r"ya29\.[0-9A-Za-z\-_]+"), Severity.CRITICAL),
-    ("GitHub PAT", re.compile(r"ghp_[a-zA-Z0-9]{36}"), Severity.CRITICAL),
+    (
+        "GitHub PAT",
+        re.compile(r"(?:ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{40,})"),
+        Severity.CRITICAL,
+    ),
     ("GitLab PAT", re.compile(r"glpat-[a-zA-Z0-9\-_]{20,}"), Severity.CRITICAL),
     ("Slack Token", re.compile(r"xox[baprs]-[0-9A-Za-z\-]{10,}"), Severity.CRITICAL),
+    ("npm Access Token", re.compile(r"npm_[A-Za-z0-9]{20,}"), Severity.CRITICAL),
+    ("PyPI API Token", re.compile(r"pypi-[A-Za-z0-9_-]{20,}"), Severity.CRITICAL),
+    (
+        "Private Key",
+        re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+        Severity.CRITICAL,
+    ),
     ("JWT", re.compile(r"eyJ[a-zA-Z0-9\-_]+\.eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+"), Severity.HIGH),
     (
         "Generic Secret Assignment",
-        re.compile(r"(?i)(api_key|secret|password|token)\s*=\s*['\"][^'\"]+['\"]"),
+        re.compile(
+            r"(?i)[\"']?(?:api[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|"
+            r"database[_-]?password|db[_-]?password|password|secret|token)[\"']?\s*[:=]\s*"
+            r"[\"']?[A-Za-z0-9_./+=:@-]{8,}"
+        ),
         Severity.HIGH,
     ),
     ("Database URL", re.compile(r"(?i)(postgres|mysql|mongodb)://\S+"), Severity.HIGH),
@@ -37,6 +54,16 @@ SECRET_ENV_VARS = (
     "DATABASE_URL",
     "GITHUB_TOKEN",
     "ANTHROPIC_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "COHERE_API_KEY",
+    "HUGGINGFACE_TOKEN",
+    "LANGFUSE_SECRET_KEY",
+    "LANGSMITH_API_KEY",
+    "MISTRAL_API_KEY",
+    "NPM_TOKEN",
+    "PINECONE_API_KEY",
+    "PYPI_API_TOKEN",
+    "WANDB_API_KEY",
 )
 
 HIDDEN_CHAR_PATTERN = re.compile(r"[\u200b-\u200f\ufeff\u202a-\u202e]")
@@ -58,6 +85,14 @@ LOGGING_CALL_PATTERN = re.compile(
 
 def _is_logging_statement(line: str) -> bool:
     return bool(LOGGING_CALL_PATTERN.search(line))
+
+
+def _redact_secrets(line: str) -> str:
+    """Return bounded context with every recognized credential removed."""
+    redacted = line
+    for _, pattern, _ in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted.strip()[:120]
 
 
 class DataLeakageAnalyzer(BaseAnalyzer):
@@ -118,7 +153,8 @@ class DataLeakageAnalyzer(BaseAnalyzer):
         for file_path, content in server.source_files.items():
             for line_no, line in enumerate(content.splitlines(), start=1):
                 for label, pattern, severity in SECRET_PATTERNS:
-                    if not pattern.search(line):
+                    match = pattern.search(line)
+                    if not match:
                         continue
                     if label == "Internal URL" and _is_logging_statement(line):
                         continue
@@ -137,7 +173,7 @@ class DataLeakageAnalyzer(BaseAnalyzer):
                             technique_id="MCTS-T-1004",
                             confidence=0.7,
                             location=SourceLocation(file=file_path, line=line_no),
-                            evidence={"pattern": pattern.pattern, "line": line.strip()[:120]},
+                            evidence={"pattern": pattern.pattern, "line": _redact_secrets(line)},
                         )
                     )
         return findings

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -65,9 +65,7 @@ def test_data_leakage_ignores_loopback_urls_in_log_messages() -> None:
         ("-----BEGIN PRIVATE KEY-----", "-----BEGIN PRIVATE KEY-----"),
     ],
 )
-def test_data_leakage_detects_and_redacts_common_secret_formats(
-    source: str, secret: str
-) -> None:
+def test_data_leakage_detects_and_redacts_common_secret_formats(source: str, secret: str) -> None:
     server = MCPServerInfo(name="secret-fixture", source_files={"config.txt": source})
 
     findings = DataLeakageAnalyzer().analyze(server)
@@ -91,6 +89,33 @@ def test_data_leakage_redacts_multiple_secrets_from_the_same_line() -> None:
     evidence = json.dumps([finding.evidence for finding in findings])
     assert anthropic_key not in evidence
     assert huggingface_token not in evidence
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'api_key = "YOUR_API_KEY"',
+        'token = "REPLACE_WITH_TOKEN"',
+        'password = "INSERT_KEY_HERE"',
+    ],
+)
+def test_data_leakage_ignores_explicit_template_secrets(source: str) -> None:
+    server = MCPServerInfo(name="template-fixture", source_files={"server.py": source})
+
+    assert DataLeakageAnalyzer().analyze(server) == []
+
+
+def test_data_leakage_does_not_hide_secret_near_template_comment() -> None:
+    secret = "real-secret-value"
+    server = MCPServerInfo(
+        name="secret-with-guidance",
+        source_files={"server.py": f'api_key = "{secret}"  # replace with YOUR_API_KEY'},
+    )
+
+    findings = DataLeakageAnalyzer().analyze(server)
+
+    assert findings
+    assert secret not in json.dumps([finding.evidence for finding in findings])
 
 
 def test_docker_dedupe_dockerfile_and_containerfile(tmp_path: Path) -> None:

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -1,6 +1,9 @@
 """Tests for source-aware analyzers."""
 
+import json
 from pathlib import Path
+
+import pytest
 
 from mcts.analyzers.command_execution import CommandExecutionAnalyzer
 from mcts.analyzers.data_leakage import DataLeakageAnalyzer
@@ -48,6 +51,44 @@ def test_data_leakage_ignores_loopback_urls_in_log_messages() -> None:
     assert len(findings) == 1
     assert findings[0].location
     assert findings[0].location.line == 4
+
+
+@pytest.mark.parametrize(
+    ("source", "secret"),
+    [
+        ("ANTHROPIC_API_KEY='sk-ant-" + "a" * 30 + "'", "sk-ant-" + "a" * 30),
+        ("token = 'hf_" + "b" * 30 + "'", "hf_" + "b" * 30),
+        ('{"apiKey": "super-secret-value"}', "super-secret-value"),
+        ("DB_PASSWORD: database-password", "database-password"),
+        ("-----BEGIN PRIVATE KEY-----", "-----BEGIN PRIVATE KEY-----"),
+    ],
+)
+def test_data_leakage_detects_and_redacts_common_secret_formats(
+    source: str, secret: str
+) -> None:
+    server = MCPServerInfo(name="secret-fixture", source_files={"config.txt": source})
+
+    findings = DataLeakageAnalyzer().analyze(server)
+
+    assert findings
+    evidence = json.dumps([finding.evidence for finding in findings])
+    assert secret not in evidence
+    assert "[REDACTED]" in evidence
+
+
+def test_data_leakage_redacts_multiple_secrets_from_the_same_line() -> None:
+    anthropic_key = "sk-ant-" + "a" * 30
+    huggingface_token = "hf_" + "b" * 30
+    server = MCPServerInfo(
+        name="two-secrets",
+        source_files={"config.txt": f"primary={anthropic_key} backup={huggingface_token}"},
+    )
+
+    findings = DataLeakageAnalyzer().analyze(server)
+
+    evidence = json.dumps([finding.evidence for finding in findings])
+    assert anthropic_key not in evidence
+    assert huggingface_token not in evidence
 
 
 def test_docker_dedupe_dockerfile_and_containerfile(tmp_path: Path) -> None:

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -60,6 +60,8 @@ def test_data_leakage_ignores_loopback_urls_in_log_messages() -> None:
         ("token = 'hf_" + "b" * 30 + "'", "hf_" + "b" * 30),
         ('{"apiKey": "super-secret-value"}', "super-secret-value"),
         ("DB_PASSWORD: database-password", "database-password"),
+        ("refreshToken: refresh-value-123", "refresh-value-123"),
+        ("Authorization: Bearer bearer-value-12345", "bearer-value-12345"),
         ("-----BEGIN PRIVATE KEY-----", "-----BEGIN PRIVATE KEY-----"),
     ],
 )


### PR DESCRIPTION
## Summary

Broadens data-leakage detection for common AI/provider credentials, modern GitHub and package-registry tokens, private-key headers, and JSON/YAML-style generic assignments. Source evidence now redacts every recognized credential on a matching line, including lines containing multiple secrets. Explicit copy-paste placeholders such as `YOUR_API_KEY`, `REPLACE_WITH_*`, and `INSERT_KEY_HERE` are ignored without suppressing a real secret merely because nearby guidance mentions a placeholder.

Closes #55

## Type of change

- [x] Bug fix
- [ ] New feature / analyzer
- [ ] Breaking change
- [ ] Documentation

## Test plan

- [ ] `uv run pytest`
- [x] Focused analyzer tests and changed-file Ruff checks
- [ ] Manual CLI test (not applicable)

Validation performed on `444c253`:

- `uv run pytest tests/test_analyzers.py -k data_leakage -q` — 14 passed, 5 deselected
- `uv run ruff check src/mcts/analyzers/data_leakage.py tests/test_analyzers.py` — passed
- `uv run ruff format --check src/mcts/analyzers/data_leakage.py tests/test_analyzers.py` — passed
- `git diff --check` — passed
- Full suite after `uv sync --all-extras` — 598 passed, 6 unrelated Windows/environment failures: two CP1252/Unicode cases plus a CP1252 live-render failure, one POSIX `.venv/bin/python` expectation, one installed-global-skills isolation expectation, and one API rate-limit test whose environment override is applied after app import. None exercise `data_leakage.py`; the focused analyzer slice is green.

## Checklist

- [x] CHANGELOG.md updated (if user-facing)
- [x] Tests added or updated
- [x] No real secrets or credentials in code (tests construct synthetic values)
- [x] Docs updated if CLI behavior or report output changed (not applicable; analyzer behavior is covered in the changelog)