### PR TITLE
feat(doctor): resolve MCP config entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Doctor MCP config entrypoints** — `mcts doctor` now resolves local Python module and script entrypoints declared in `.mcp.json`.
 - **Attack graph Phase 3c polish** — FixKind registry with runtime `graph_mutate` engine (apply registry `mutates` and simulate template elimination), inventory multi-server graph layer (`graph_inventory`), counterfactual fix simulation on paths, default-on counterfactuals and UI compression (`--no-attack-graph-counterfactuals`, `--no-attack-graph-compress-ui`), dashboard layer filter + policy/inferred edge styling, `mcts doctor --suggest-fixes --report`
 - **`mcts inventory` privacy controls** — `--paths-only`, `--config-path`, `--redact-paths`; documented in `SECURITY.md` (#87)
 

--- a/docs/platform/cli.md
+++ b/docs/platform/cli.md
@@ -26,6 +26,8 @@ Complete reference for every MCTS command and flag. Use this when you need to lo
 
 ## `mcts doctor`
 
+When a local `.mcp.json` declares a Python `-m package.module` or script-path launch argument, Doctor includes the resolved local file as an entrypoint candidate.
+
 Read-only preflight checks before your first scan (no live probes).
 
 ```bash

--- a/src/mcts/discovery/onboarding.py
+++ b/src/mcts/discovery/onboarding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from mcts.discovery.config import list_server_names
@@ -52,7 +53,10 @@ def find_entrypoint_candidates(root: Path, *, limit: int = 5) -> list[Path]:
     base = root.expanduser().resolve()
     if not base.is_dir():
         return []
-    scored: list[tuple[int, Path]] = []
+    scored: dict[Path, int] = {}
+    for path in _config_entrypoints(base):
+        if path.is_file() and not _should_skip(path, base):
+            scored[path] = 100
     for path in base.rglob("*.py"):
         if _should_skip(path, base):
             continue
@@ -68,10 +72,34 @@ def find_entrypoint_candidates(root: Path, *, limit: int = 5) -> list[Path]:
             score += 2
         if "/mcp/" in f"/{path.relative_to(base).as_posix()}/":
             score += 1
-        scored.append((score, path))
+        scored[path] = max(scored.get(path, 0), score)
 
-    scored.sort(key=lambda item: (-item[0], str(item[1])))
-    return [path for _, path in scored[:limit]]
+    return sorted(scored, key=lambda path: (-scored[path], str(path)))[:limit]
+
+
+def _config_entrypoints(root: Path) -> list[Path]:
+    """Resolve local Python entrypoint paths declared in MCP client configs."""
+    paths: list[Path] = []
+    for config_path in find_mcp_configs(root):
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        servers = config.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            continue
+        for server in servers.values():
+            if not isinstance(server, dict):
+                continue
+            args = server.get("args", [])
+            if not isinstance(args, list):
+                continue
+            for index, arg in enumerate(args):
+                if arg == "-m" and index + 1 < len(args) and isinstance(args[index + 1], str):
+                    paths.append(root / (args[index + 1].replace(".", "/") + ".py"))
+                elif isinstance(arg, str) and arg.endswith(".py"):
+                    paths.append(root / arg)
+    return paths
 
 
 def format_discovery_hints(root: Path) -> str:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -38,6 +38,30 @@ def test_entrypoint_candidates_skips_tests_dir(tmp_path: Path) -> None:
     assert tests not in candidates
 
 
+def test_entrypoint_candidates_include_module_and_script_from_mcp_config(tmp_path: Path) -> None:
+    bridge = tmp_path / "ifd_backend" / "bridge.py"
+    bridge.parent.mkdir()
+    bridge.write_text("def main(): pass\n")
+    script = tmp_path / "tools" / "server.py"
+    script.parent.mkdir()
+    script.write_text("def main(): pass\n")
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "bridge": {"command": "python", "args": ["-m", "ifd_backend.bridge"]},
+                    "script": {"command": "python", "args": ["tools/server.py"]},
+                }
+            }
+        )
+    )
+
+    candidates = find_entrypoint_candidates(tmp_path)
+
+    assert bridge in candidates
+    assert script in candidates
+
+
 def test_format_discovery_hints_includes_config(tmp_path: Path) -> None:
     config = tmp_path / ".mcp.json"
     config.write_text(json.dumps({"mcpServers": {"local": {"command": "python"}}}))


### PR DESCRIPTION
## Summary

Resolve local Python module (`-m package.module`) and script-path launch arguments from discovered MCP configs so Doctor can suggest the actual entrypoint files.

Fixes #200

## Type of change

- [x] New feature / analyzer

## Test plan

- [x] `uv run pytest tests/test_onboarding.py -q`
- [x] `uv run ruff check src tests`

## Checklist

- [x] CHANGELOG.md updated
- [x] Tests added or updated
- [x] No secrets or credentials in code
- [x] Docs updated