### PR TITLE
fix(discovery): include root-level Python entrypoints in directory scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include root-level Python MCP entrypoints in recursive directory scans instead of silently skipping them when the default `**/*.py` include glob is applied ([#316](https://github.com/MCP-Audit/MCTS/issues/316))
+
 ## [0.1.4] - 2026-06-12
 
 ### Security

--- a/src/mcts/discovery/static.py
+++ b/src/mcts/discovery/static.py
@@ -94,9 +94,11 @@ class StaticDiscovery:
         if any(part in self.config.exclude_dirs for part in rel.parts):
             return False
         rel_str = str(rel)
-        if self.config.exclude_globs and any(fnmatch(rel_str, g) for g in self.config.exclude_globs):
+        if self.config.exclude_globs and any(_matches_glob(rel_str, g) for g in self.config.exclude_globs):
             return False
-        if self.config.include_globs and not any(fnmatch(rel_str, g) for g in self.config.include_globs):
+        if self.config.include_globs and not any(
+            _matches_glob(rel_str, g) for g in self.config.include_globs
+        ):
             return False
         try:
             if path.stat().st_size > self.config.max_file_bytes:
@@ -161,6 +163,15 @@ class StaticDiscovery:
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == func_name:
                 return ast.get_docstring(node) or ""
         return ""
+
+
+def _matches_glob(relative_path: str, pattern: str) -> bool:
+    """Match a relative path while allowing ``**/`` to match the root level."""
+    normalized_path = relative_path.replace("\\", "/")
+    normalized_pattern = pattern.replace("\\", "/")
+    if fnmatch(normalized_path, normalized_pattern):
+        return True
+    return normalized_pattern.startswith("**/") and fnmatch(normalized_path, normalized_pattern[3:])
 
 
 def _schema_from_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> dict[str, Any]:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 
+from mcts.analyzers.command_execution import CommandExecutionAnalyzer
 from mcts.core.config import ScanConfig
 from mcts.core.scanner import Scanner
 from mcts.discovery.static import StaticDiscovery
+from mcts.reporting.models import Severity
 
 BENCH_REPO = Path(__file__).parent.parent / "examples" / "bench" / "multi-file-server"
 
@@ -33,3 +35,26 @@ def test_scan_repo_directory() -> None:
     report = Scanner(ScanConfig(target=BENCH_REPO)).run()
     assert len(report.server.tools) >= 2
     assert report.attack_graph.get("edges")
+
+
+def test_static_discovery_includes_root_level_entrypoint(tmp_path: Path) -> None:
+    server_path = tmp_path / "server.py"
+    server_path.write_text(
+        """
+import subprocess
+
+@mcp.tool()
+def run_diagnostic(target: str) -> str:
+    return subprocess.run(target, shell=True, capture_output=True, text=True).stdout
+""",
+        encoding="utf-8",
+    )
+
+    info = StaticDiscovery(ScanConfig(target=tmp_path)).discover()
+
+    assert str(server_path) in info.source_files
+    assert {tool.name for tool in info.tools} == {"run_diagnostic"}
+    findings = CommandExecutionAnalyzer().analyze(info)
+    assert any(
+        finding.tool == "run_diagnostic" and finding.severity == Severity.CRITICAL for finding in findings
+    )


### PR DESCRIPTION
## Summary

- make the default recursive `**/*.py` include glob match Python files directly under the scanned directory
- apply the same root-aware matching to configured exclude globs
- add a regression that verifies a root-level MCP entrypoint reaches the command-execution analyzer
- document the fix in the changelog

Fixes #316

## Verification

- `uv run pytest tests/test_discovery.py tests/test_auto_scan.py -q`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pre-commit run --files src/mcts/discovery/static.py tests/test_discovery.py CHANGELOG.md`

A directory scan of a root-level `server.py` now discovers the same tools and source-level command-execution findings as scanning that file directly.