### PR TITLE
fix(pentest): deduplicate repeated verdict findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Deduplicate repeated analyzer findings by stable root-cause ID when deriving the `mcts pentest` verdict, so duplicate observations no longer inflate v2 risk levels while distinct findings remain counted.
+
 ## [0.1.4] - 2026-06-12
 
 ### Security

--- a/src/mcts/pentest/runner.py
+++ b/src/mcts/pentest/runner.py
@@ -6,7 +6,7 @@ from mcts.core.config import ScanConfig
 from mcts.core.scanner import Scanner
 from mcts.fuzz.runner import FuzzRunner
 from mcts.pentest.models import PentestLimits, PentestPhase, PentestReport
-from mcts.reporting.models import Finding, ScanReport, Severity
+from mcts.reporting.models import Finding, ScanReport, ScanSummary, Severity
 
 
 def run_pentest(config: ScanConfig, *, run_fuzz: bool = True) -> PentestReport:
@@ -83,7 +83,7 @@ def run_pentest(config: ScanConfig, *, run_fuzz: bool = True) -> PentestReport:
 
     combined = _rank_findings(static_report, fuzz_rows)
     recommendations = _recommendations(static_report, fuzz_rows, attack_paths)
-    verdict = _verdict(static_report, fuzz_rows)
+    verdict = _verdict(static_report, fuzz_rows, config)
 
     limits = PentestLimits(
         tools_discovered=len(static_report.server.tools),
@@ -116,16 +116,60 @@ def _rank_findings(static_report: ScanReport, fuzz_rows: list[Finding]) -> list[
     return sorted(combined, key=lambda row: (order.get(row.severity, 99), row.title))
 
 
-def _verdict(static_report: ScanReport, fuzz_rows: list[Finding]) -> str:
+def _deduplicate_findings(findings: list[Finding]) -> list[Finding]:
+    """Keep one finding per analyzer-emitted root-cause ID without mutating the report."""
+    seen: set[tuple[str, str]] = set()
+    unique: list[Finding] = []
+    for finding in findings:
+        key = (finding.analyzer, finding.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(finding)
+    return unique
+
+
+def _verdict(
+    static_report: ScanReport,
+    fuzz_rows: list[Finding],
+    config: ScanConfig | None = None,
+) -> str:
+    """Derive the pentest verdict from unique root causes, not repeated observations.
+
+    ``config`` is optional for compatibility with callers of this private helper. The
+    production path supplies it so a v2 verdict can be recomputed from the deduplicated
+    findings while the full scan report retains every original observation.
+    """
+    static_findings = _deduplicate_findings(static_report.findings)
+    unique_fuzz_rows = _deduplicate_findings(fuzz_rows)
+
     if static_report.score_v2 is not None:
-        if any(f.severity == Severity.CRITICAL for f in fuzz_rows):
+        score_v2 = static_report.score_v2
+        if config is not None:
+            from mcts.scoring.context import build_scoring_context
+            from mcts.scoring.engine import RiskScoringEngine
+            from mcts.scoring.engine_v2 import RiskScoringEngineV2
+
+            context = build_scoring_context(
+                findings=static_findings,
+                server=static_report.server,
+                attack_graph=static_report.attack_graph,
+                scan_scope=static_report.scan_scope,
+                config=config,
+                chain_factor_mode="paths_v1" if config.enable_attack_chains else "disabled",
+            )
+            legacy_score = RiskScoringEngine().score(static_findings)
+            score_v2 = RiskScoringEngineV2().score(context, legacy_overall=legacy_score.overall)
+        if any(f.severity == Severity.CRITICAL for f in unique_fuzz_rows):
             return "critical"
-        return static_report.score_v2.risk_level
-    if static_report.summary.critical:
+        return score_v2.risk_level
+
+    summary = ScanSummary.from_findings(static_findings)
+    if summary.critical:
         return "critical"
-    if static_report.summary.high or any(f.severity == Severity.HIGH for f in fuzz_rows):
+    if summary.high or any(f.severity == Severity.HIGH for f in unique_fuzz_rows):
         return "high"
-    if static_report.summary.medium or static_report.findings or fuzz_rows:
+    if summary.medium or static_findings or unique_fuzz_rows:
         return "medium"
     return "pass"
 

--- a/tests/scoring/test_pentest_paths.py
+++ b/tests/scoring/test_pentest_paths.py
@@ -1,9 +1,52 @@
 """Pentest attack_paths integration."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 from mcts.core.config import ScanConfig
-from mcts.pentest.runner import run_pentest
+from mcts.mcp.models import MCPServerInfo
+from mcts.pentest.runner import _deduplicate_findings, _verdict, run_pentest
+from mcts.reporting.models import Finding, ScanReport, ScanSummary, Severity
+from mcts.scoring.context import build_scoring_context
+from mcts.scoring.engine import RiskScoringEngine
+from mcts.scoring.engine_v2 import RiskScoringEngineV2
+
+
+def _high_finding(finding_id: str) -> Finding:
+    return Finding(
+        id=finding_id,
+        analyzer="supply_chain",
+        title="Docker base image not digest-pinned",
+        description="FROM python:latest",
+        severity=Severity.HIGH,
+        recommendation="Pin the image by digest.",
+        evidence={"image": "python:latest"},
+    )
+
+
+def _scored_report(findings: list[Finding], config: ScanConfig) -> ScanReport:
+    server = MCPServerInfo(name="fixture")
+    legacy_score = RiskScoringEngine().score(findings)
+    context = build_scoring_context(
+        findings=findings,
+        server=server,
+        attack_graph={},
+        scan_scope="repository",
+        config=config,
+        chain_factor_mode="disabled",
+    )
+    score_v2 = RiskScoringEngineV2().score(context, legacy_overall=legacy_score.overall)
+    return ScanReport(
+        version="0.0.0",
+        target="fixture",
+        scanned_at=datetime.now(UTC),
+        server=server,
+        findings=findings,
+        summary=ScanSummary.from_findings(findings),
+        score=legacy_score,
+        score_v2=score_v2,
+        scoring_version="v2",
+    )
 
 
 def test_pentest_paths_populated() -> None:
@@ -24,3 +67,26 @@ def test_pentest_verdict_uses_v2_risk_level() -> None:
     )
     assert report.absolute_risk is not None
     assert report.verdict in {"low", "medium", "high", "critical", "pass"}
+
+
+def test_pentest_verdict_deduplicates_v2_root_causes() -> None:
+    config = ScanConfig(target=Path("fixture"), scoring_mode="v2", enable_attack_chains=False)
+    duplicate_root = [_high_finding("same-root") for _ in range(3)]
+    duplicate_report = _scored_report(duplicate_root, config)
+    single_report = _scored_report([duplicate_root[0]], config)
+
+    assert duplicate_report.score_v2 is not None
+    assert single_report.score_v2 is not None
+    assert duplicate_report.score_v2.risk_level != single_report.score_v2.risk_level
+    assert _verdict(duplicate_report, [], config) == single_report.score_v2.risk_level
+    assert _verdict(duplicate_report, [], config) != duplicate_report.score_v2.risk_level
+
+
+def test_pentest_verdict_keeps_distinct_root_causes() -> None:
+    config = ScanConfig(target=Path("fixture"), scoring_mode="v2", enable_attack_chains=False)
+    findings = [_high_finding("root-python"), _high_finding("root-node")]
+    report = _scored_report(findings, config)
+
+    assert _deduplicate_findings(findings) == findings
+    assert report.score_v2 is not None
+    assert _verdict(report, [], config) == report.score_v2.risk_level


### PR DESCRIPTION
## Summary

- deduplicate repeated analyzer observations by their stable `(analyzer, finding ID)` root-cause key when deriving the pentest verdict
- recompute the v2 risk level from unique static findings while retaining the full report observations and evidence
- keep distinct finding IDs and unique fuzz findings counted independently

Fixes #198

## Verification

- `uv run --frozen pytest tests/test_pentest.py tests/scoring/test_pentest_paths.py -q` — 8 passed
- `uv run --frozen pytest -q --ignore=tests/test_new_features.py --ignore=tests/test_skills_inventory.py --ignore=tests/test_technique_regression.py` — 493 passed
- `uv run --frozen ruff check src tests` — passed
- `uv run --frozen ruff format --check src tests` — passed
- `uv run --frozen pre-commit run --files CHANGELOG.md src/mcts/pentest/runner.py tests/scoring/test_pentest_paths.py` — passed
- staged `gitleaks protect --staged --redact --no-banner` — no leaks

The unfiltered local suite also exposed unrelated environment-only failures: a protocol test inherited a SOCKS proxy without `socksio`, skill inventory included machine-global skills, and proxy-cleared regression coverage attempted an unavailable HuggingFace model download. None touches the changed files.